### PR TITLE
Fix typos and outdated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # arduino/report-size-deltas action
 
-This action comments on the pull request with a report on the change in memory usage of an example sketch. This should be run from a [scheduled workflow](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule).
+This action comments on the pull request with a report on the resulting change in memory usage of the [Arduino](https://www.arduino.cc/) sketches compiled by the [`arduino/compile-sketches`](https://github.com/arduino/compile-sketches) action. This should be run from a [scheduled workflow](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule).
 
 ## Inputs
 
 ### `size-deltas-reports-artifact-name`
 
-Name of the workflow artifact that contains the memory usage data, as specified to the actions/upload-artifact action via the name argument. Default "size-deltas-reports".
+Name of the workflow artifact that contains the memory usage data, as specified to the [`actions/upload-artifact`](https://github.com/actions/upload-artifact) action via its `name` input. Default "size-deltas-reports".
 
 ### `github-token`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# libraries/report-size-deltas action
+# arduino/report-size-deltas action
 
 This action comments on the pull request with a report on the change in memory usage of an example sketch. This should be run from a [scheduled workflow](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule).
 
@@ -22,5 +22,5 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: arduino/actions/libraries/report-size-deltas@master
+      - uses: arduino/report-size-deltas@master
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: 'Report Arduino Sketch Size Deltas'
-description: 'Comments on the pull request with a report on the change in memory usage of an example sketch'
+description: 'Comments on the pull request with a report on the resulting change in memory usage of Arduino sketches'
 inputs:
   size-deltas-reports-artifact-name:
-    description: 'Name of the workflow artifact that contains the memory usage data, as specified to the actions/upload-artifact action via the name argument'
+    description: 'Name of the workflow artifact that contains the memory usage data, as specified to the actions/upload-artifact action via its name input'
     default: 'size-deltas-reports'
   github-token:
     description: 'GitHub access token used to comment the memory usage comparison results to the PR thread'

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Arduino Libraries - Report Size Deltas'
+name: 'Report Arduino Sketch Size Deltas'
 description: 'Comments on the pull request with a report on the change in memory usage of an example sketch'
 inputs:
   size-deltas-reports-artifact-name:


### PR DESCRIPTION
The move to new repository resulted in some parts of the documentation needing updates.