### PR TITLE
Support using sketches reports from local path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This action comments on the pull request with a report on the resulting change i
 
 ## Inputs
 
-### `size-deltas-reports-artifact-name`
+### `sketches-reports-source-name`
 
 Name of the [workflow artifact](https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts) that contains the memory usage data, as specified to the [`actions/upload-artifact`](https://github.com/actions/upload-artifact) action via its `name` input.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,29 @@ This action comments on the pull request with a report on the resulting change i
 
 ### `sketches-reports-source-name`
 
-Name of the [workflow artifact](https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts) that contains the memory usage data, as specified to the [`actions/upload-artifact`](https://github.com/actions/upload-artifact) action via its `name` input.
+**Default**: "size-deltas-reports"
 
-**Default**: `"size-deltas-reports"`
+The action can be used in two ways:
+
+#### Run from a [scheduled workflow](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule)
+
+Recommended for public repositories.
+
+The use of a scheduled workflow is necessary in order for the action to have the [write permissions required to comment on pull requests submitted from forks](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token).
+
+In this usage, the `sketches-reports-source-name` defines the name of the workflow artifact that contains the memory usage data, as specified to the [`actions/upload-artifact`](https://github.com/actions/upload-artifact) action via its `name` input.
+
+#### Run from the same workflow as the [`arduino/compile-sketches`](https://github.com/arduino/compile-sketches) action
+
+Recommended for private repositories.
+
+If configured to trigger on a short interval, the scheduled workflow method can use a lot of GitHub Actions minutes, quickly using up the limited allotment provided by GitHub for private repositories (public repositories get unlimited free minutes). For this reason, it may be preferable to only run the action as needed.
+
+In order to get reports for pull requests from forks, the ["Send write tokens to workflows from fork pull requests" setting](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#enabling-workflows-for-private-repository-forks) must be enabled.
+
+If the "Send write tokens to workflows from fork pull requests" setting is not enabled but the ["Run workflows from fork pull requests" setting](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#enabling-workflows-for-private-repository-forks) is enabled, the workflow should be configured to only run the action when the pull request is not from a fork (`if: github.event.pull_request.head.repo.full_name == github.repository`). This will prevent workflow job failures that would otherwise be caused when the report creation failed due to not having the necessary write permissions.
+
+In this usage, the `sketches-reports-source-name` defines the path to the folder containing the memory usage data, as specified to the [`actions/download-artifact`](https://github.com/actions/download-artifact) action via its `path` input.
 
 ### `github-token`
 
@@ -21,6 +41,8 @@ Name of the [workflow artifact](https://docs.github.com/en/actions/configuring-a
 **Default**: [`GITHUB_TOKEN`](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)
 
 ## Example usage
+
+### Scheduled workflow
 
 ```yaml
 on:
@@ -48,4 +70,54 @@ jobs:
         with:
           name: size-deltas-reports
           path: size-deltas-reports
+```
+
+### Workflow triggered by `pull_request` event
+
+```yaml
+on: [push, pull_request]
+env:
+  # It's convenient to set variables for values used multiple times in the workflow
+  SKETCHES_REPORTS_PATH: sketches-reports
+  SKETCHES_REPORTS_ARTIFACT_NAME: sketches-reports
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fqbn:
+          - "arduino:avr:uno"
+          - "arduino:samd:mkrzero"
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: arduino/compile-sketches@main
+        with:
+          fqbn: ${{ matrix.fqbn }}
+          enable-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+
+      # This step is needed to pass the size data to the report job 
+      - name: Upload sketches report to workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+
+  # When using a matrix to compile for multiple boards, it's necessary to use a separate job for the deltas report
+  report:
+    needs: compile  # Wait for the compile job to finish to get the data for the report
+    if: github.event_name == 'pull_request' # Only run the job when the workflow is triggered by a pull request
+    runs-on: ubuntu-latest
+    steps:
+      # This step is needed to get the size data produced by the compile job
+      - name: Download sketches reports artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+
+      - uses: arduino/report-size-deltas@main
+        with:
+          sketches-reports-source-name: ${{ env.SKETCHES_REPORTS_PATH }}
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This action comments on the pull request with a report on the resulting change i
 
 ## Inputs
 
-### `sketches-reports-source-name`
+### `sketches-reports-source`
 
 **Default**: "size-deltas-reports"
 
@@ -20,7 +20,7 @@ Recommended for public repositories.
 
 The use of a scheduled workflow is necessary in order for the action to have the [write permissions required to comment on pull requests submitted from forks](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token).
 
-In this usage, the `sketches-reports-source-name` defines the name of the workflow artifact that contains the memory usage data, as specified to the [`actions/upload-artifact`](https://github.com/actions/upload-artifact) action via its `name` input.
+In this usage, the `sketches-reports-source` defines the name of the workflow artifact that contains the memory usage data, as specified to the [`actions/upload-artifact`](https://github.com/actions/upload-artifact) action via its `name` input.
 
 #### Run from the same workflow as the [`arduino/compile-sketches`](https://github.com/arduino/compile-sketches) action
 
@@ -32,7 +32,7 @@ In order to get reports for pull requests from forks, the ["Send write tokens to
 
 If the "Send write tokens to workflows from fork pull requests" setting is not enabled but the ["Run workflows from fork pull requests" setting](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#enabling-workflows-for-private-repository-forks) is enabled, the workflow should be configured to only run the action when the pull request is not from a fork (`if: github.event.pull_request.head.repo.full_name == github.repository`). This will prevent workflow job failures that would otherwise be caused when the report creation failed due to not having the necessary write permissions.
 
-In this usage, the `sketches-reports-source-name` defines the path to the folder containing the memory usage data, as specified to the [`actions/download-artifact`](https://github.com/actions/download-artifact) action via its `path` input.
+In this usage, the `sketches-reports-source` defines the path to the folder containing the memory usage data, as specified to the [`actions/download-artifact`](https://github.com/actions/download-artifact) action via its `path` input.
 
 ### `github-token`
 
@@ -110,7 +110,7 @@ jobs:
     if: github.event_name == 'pull_request' # Only run the job when the workflow is triggered by a pull request
     runs-on: ubuntu-latest
     steps:
-      # This step is needed to get the size data produced by the compile job
+      # This step is needed to get the size data produced by the compile jobs
       - name: Download sketches reports artifact
         uses: actions/download-artifact@v2
         with:
@@ -119,5 +119,5 @@ jobs:
 
       - uses: arduino/report-size-deltas@main
         with:
-          sketches-reports-source-name: ${{ env.SKETCHES_REPORTS_PATH }}
+          sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'Report Arduino Sketch Size Deltas'
 description: 'Comments on the pull request with a report on the resulting change in memory usage of Arduino sketches'
 inputs:
-  sketches-reports-source-name:
+  sketches-reports-source:
     description: 'When run from scheduled workflow, name of the workflow artifact that contains sketches reports. When run from a pull request triggered workflow, path to the folder containing sketches reports.'
     default: 'size-deltas-reports'
   github-token:

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: 'Report Arduino Sketch Size Deltas'
 description: 'Comments on the pull request with a report on the resulting change in memory usage of Arduino sketches'
 inputs:
-  size-deltas-reports-artifact-name:
-    description: 'Name of the workflow artifact that contains the memory usage data, as specified to the actions/upload-artifact action via its name input'
+  sketches-reports-source-name:
+    description: 'When run from scheduled workflow, name of the workflow artifact that contains sketches reports. When run from a pull request triggered workflow, path to the folder containing sketches reports.'
     default: 'size-deltas-reports'
   github-token:
     description: 'GitHub access token used to comment the memory usage comparison results to the PR thread'

--- a/reportsizedeltas/tests/data/test_report_size_deltas_pull_request/githubevent.json
+++ b/reportsizedeltas/tests/data/test_report_size_deltas_pull_request/githubevent.json
@@ -1,0 +1,8 @@
+{
+  "pull_request": {
+    "head": {
+      "sha": "pull_request-head-sha"
+    },
+    "number": 42
+  }
+}

--- a/reportsizedeltas/tests/test_reportsizedeltas.py
+++ b/reportsizedeltas/tests/test_reportsizedeltas.py
@@ -832,8 +832,9 @@ def test_handle_rate_limiting():
     report_size_deltas.handle_rate_limiting()
 
 
-@pytest.mark.slow(reason="Causes a delay")
-def test_determine_urlopen_retry_true():
+def test_determine_urlopen_retry_true(mocker):
+    mocker.patch("time.sleep", autospec=True)
+
     assert reportsizedeltas.determine_urlopen_retry(
         exception=urllib.error.HTTPError(None, 502, "Bad Gateway", None, None))
 


### PR DESCRIPTION
The action was previously designed to only run from a scheduled workflow. The reason is that it needs a token with write permissions to comment on the PR, but due to security restrictions there is no way to have such a token when a
workflow is triggered by a pull_request event from a fork.

This is problematic for private repos because if the schedule is set to a short interval the action will use up the free GitHub actoins minutes allocation quickly (public repos have unlimited minutes). If the schedule is set to a long
interval, then there is a long potential wait time for the report.

A common work flow in private repos is for PRs to be submitted from branches, not forks, which makes it possible to trigger the action from the PR.

Running from a pull request triggered workflow should actually work as the action was, but the method of finding the artifact is very inefficient and unintuitive in that context.

Recently, GitHub added the ability for private repositories to allow write permissions for workflows triggered by pull requests, making it even more likely this method of using the action will be found useful:
https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#enabling-workflows-for-private-repository-forks

---
Due to now supporting multiple sources of sketches reports, the input name `size-deltas-reports-artifact-name` was no longer appropriate (this input is now used for specifying the workflow artifact name when used in the traditional scheduled workflow method and for specifying the local folder name when using the new pull request triggered workflow method), so it has been renamed `sketches-reports-source`.

The previous input name is still supported, but a warning will be displayed in the build log recommending switching to the new input name.

---
Demonstration of the action used in a pull request triggered workflow:
https://github.com/per1234/report-size-deltas/pull/1#issuecomment-691649959
This is using the exact workflow from the readme, except with the `arduino/report-size-deltas@main` action name changed to `per1234/report-size-deltas@local-report-support` so it can use the version of the action with the implementation of this proposal.