### PR TITLE
Add table of contents to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@
 
 This action comments on the pull request with a report on the resulting change in memory usage of the [Arduino](https://www.arduino.cc/) sketches compiled by the [`arduino/compile-sketches`](https://github.com/arduino/compile-sketches) action. This should be run from a [scheduled workflow](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule).
 
+## Table of contents
+
+<!-- toc -->
+
+- [Inputs](#inputs)
+  - [`sketches-reports-source`](#sketches-reports-source)
+    - [Run from a scheduled workflow](#run-from-a-scheduled-workflow)
+    - [Run from the same workflow as the `arduino/compile-sketches` action](#run-from-the-same-workflow-as-the-arduinocompile-sketches-action)
+  - [`github-token`](#github-token)
+- [Example usage](#example-usage)
+  - [Scheduled workflow](#scheduled-workflow)
+  - [Workflow triggered by `pull_request` event](#workflow-triggered-by-pull_request-event)
+
+<!-- tocstop -->
+
 ## Inputs
 
 ### `sketches-reports-source`


### PR DESCRIPTION
Generated using https://github.com/jonschlinkert/markdown-toc

```
npm install --global markdown-toc
markdown-toc --bullets=- --maxdepth=5 -i ./README.md
```

The links in the headings had to be removed manually after generating the ToC.