### PR TITLE
Use appropriate default value for sketches-reports-source input

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This action comments on the pull request with a report on the resulting change i
 
 ### `sketches-reports-source`
 
-**Default**: "size-deltas-reports"
+**Default**: "sketches-reports"
 
 The action can be used in two ways:
 
@@ -68,8 +68,8 @@ jobs:
           enable-deltas-report: true
       - uses: actions/upload-artifact@v2
         with:
-          name: size-deltas-reports
-          path: size-deltas-reports
+          name: sketches-reports
+          path: sketches-reports
 ```
 
 ### Workflow triggered by `pull_request` event

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Comments on the pull request with a report on the resulting change
 inputs:
   sketches-reports-source:
     description: 'When run from scheduled workflow, name of the workflow artifact that contains sketches reports. When run from a pull request triggered workflow, path to the folder containing sketches reports.'
-    default: 'size-deltas-reports'
+    default: 'sketches-reports'
   github-token:
     description: 'GitHub access token used to comment the memory usage comparison results to the PR thread'
     default: ${{ github.token }}


### PR DESCRIPTION
In the time since it was first conceived, the use of the report file created by the `arduino/compile-sketches` action has been expanded from only being a way to pass memory usage change data to the `arduino/report-size-deltas` action to a general purpose report of data generated from the sketch compilations, including:

- Non-deltas size data consumed by `arduino/report-size-trends`
- Compilation status for each sketch/board combination
- Compiler warning count

It's possible additional information will be added to the report over time.

For this reason, the previous default of the `arduino/compile-sketches` action's `sketches-report-path` input: `size-deltas-reports` was no longer appropriate and had to be changed to avoid confusion. Even though `arduino/report-size-deltas` only uses the deltas data from the report, and so the previous default was somewhat logical, I think it's best for the same default name to be used for the folder and workflow artifacts containing the reports consistently across all the actions that use this report.

Unfortunately, this will be a breaking change for people who have not specified the action's `sketches-reports-source` input in their workflow and are thus relying on the default value.