### PR TITLE
Skip expired workflow artifacts

### DIFF
--- a/reportsizedeltas/reportsizedeltas.py
+++ b/reportsizedeltas/reportsizedeltas.py
@@ -239,7 +239,7 @@ class ReportSizeDeltas:
 
             for artifact_data in artifacts_data["artifacts"]:
                 # The artifact is identified by a specific name
-                if artifact_data["name"] == self.sketches_reports_source:
+                if not artifact_data["expired"] and artifact_data["name"] == self.sketches_reports_source:
                     return artifact_data["archive_download_url"]
 
             page_number += 1


### PR DESCRIPTION
Workflow artifacts expire after a default of 90 days. For some reason, the GitHub workflow artifacts API
still lists these artifacts, even though they are no longer available. Previously, if the repository contained an open
PR with an expired artifact, it caused the action to fail when it tried to download the non-existent artifact and got an
HTTP 500 error.

Example:
https://github.com/arduino-libraries/ArduinoIoTCloud/runs/1403885124?check_suite_focus=true#step:3:31

Successful workflow run after this change:
https://github.com/arduino-libraries/ArduinoIoTCloud/runs/1404096185?check_suite_focus=true