### PR TITLE
Use major version refs in example snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: arduino/report-size-deltas@main
+      - uses: arduino/report-size-deltas@v1
 ```
 
 This must be used in conjunction with a workflow that runs the [`arduino/compile-sketches`](https://github.com/arduino/compile-sketches) action and uploads the resulting sketches report to a [workflow artifact](https://help.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts):
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: arduino/compile-sketches@main
+      - uses: arduino/compile-sketches@v1
         with:
           enable-deltas-report: true
       - uses: actions/upload-artifact@v2
@@ -108,7 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: arduino/compile-sketches@main
+      - uses: arduino/compile-sketches@v1
         with:
           fqbn: ${{ matrix.fqbn }}
           enable-deltas-report: true
@@ -134,7 +134,7 @@ jobs:
           name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}
 
-      - uses: arduino/report-size-deltas@main
+      - uses: arduino/report-size-deltas@v1
         with:
           sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}
 ```


### PR DESCRIPTION
Previously, due to the lack of releases, the only option was to use the default branch name for the action refs. Using release versions provides a more stable experience for the ordinary users of these actions and also eases ongoing development work on the actions.

Use of the major version ref will cause the workflow to benefit from ongoing development to the action at each patch or minor release up until such time as a new major release is made, at which time the user will be given the opportunity to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before manually updating the major ref (e.g., `uses: arduino/report-size-deltas@v2`).