### PR TITLE
[DO NOT MERGE] Dummy PR for test deltas report target

### DIFF
--- a/.github/workflows/testdata/artifact-source/multi-report-artifact/arduino-avr-leonardo.json
+++ b/.github/workflows/testdata/artifact-source/multi-report-artifact/arduino-avr-leonardo.json
@@ -1,0 +1,245 @@
+{
+  "commit_hash": "0123456789abcdef0123456789abcdef01234567",
+  "commit_url": "https://github.com/per1234/generate-size-deltas-report/commit/651f05f4d4aca30ac359e972c01568f873112d43",
+  "boards": [
+    {
+      "board": "arduino:avr:leonardo",
+      "sketches": [
+        {
+          "name": "examples/MIDIUSB_clock",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 28672,
+              "current": {
+                "absolute": 4792,
+                "relative": 16.71
+              },
+              "previous": {
+                "absolute": 4792,
+                "relative": 16.71
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 2560,
+              "current": {
+                "absolute": 443,
+                "relative": 17.3
+              },
+              "previous": {
+                "absolute": 443,
+                "relative": 17.3
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 2
+            },
+            "previous": {
+              "absolute": 2
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_loop",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 28672,
+              "current": {
+                "absolute": 4870,
+                "relative": 16.99
+              },
+              "previous": {
+                "absolute": 4870,
+                "relative": 16.99
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 2560,
+              "current": {
+                "absolute": 441,
+                "relative": 17.23
+              },
+              "previous": {
+                "absolute": 441,
+                "relative": 17.23
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 3
+            },
+            "previous": {
+              "absolute": 3
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_read",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 28672,
+              "current": {
+                "absolute": 4908,
+                "relative": 17.12
+              },
+              "previous": {
+                "absolute": 4908,
+                "relative": 17.12
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 2560,
+              "current": {
+                "absolute": 457,
+                "relative": 17.85
+              },
+              "previous": {
+                "absolute": 457,
+                "relative": 17.85
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 3
+            },
+            "previous": {
+              "absolute": 3
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_write",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 28672,
+              "current": {
+                "absolute": 4524,
+                "relative": 15.78
+              },
+              "previous": {
+                "absolute": 4564,
+                "relative": 15.92
+              },
+              "delta": {
+                "absolute": -40,
+                "relative": -0.14
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 2560,
+              "current": {
+                "absolute": 197,
+                "relative": 7.7
+              },
+              "previous": {
+                "absolute": 213,
+                "relative": 8.32
+              },
+              "delta": {
+                "absolute": -16,
+                "relative": -0.62
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 3
+            },
+            "previous": {
+              "absolute": 3
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        }
+      ],
+      "sizes": [
+        {
+          "name": "flash",
+          "maximum": 28672,
+          "delta": {
+            "absolute": {
+              "minimum": -40,
+              "maximum": 0
+            },
+            "relative": {
+              "minimum": -0.14,
+              "maximum": 0.0
+            }
+          }
+        },
+        {
+          "name": "RAM for global variables",
+          "maximum": 2560,
+          "delta": {
+            "absolute": {
+              "minimum": -16,
+              "maximum": 0
+            },
+            "relative": {
+              "minimum": -0.62,
+              "maximum": 0.0
+            }
+          }
+        }
+      ],
+      "warnings": {
+        "delta": {
+          "absolute": {
+            "minimum": 0,
+            "maximum": 0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/.github/workflows/testdata/artifact-source/multi-report-artifact/arduino-sam-arduino_due_x.json
+++ b/.github/workflows/testdata/artifact-source/multi-report-artifact/arduino-sam-arduino_due_x.json
@@ -1,0 +1,245 @@
+{
+  "commit_hash": "0123456789abcdef0123456789abcdef01234567",
+  "commit_url": "https://github.com/per1234/generate-size-deltas-report/commit/651f05f4d4aca30ac359e972c01568f873112d43",
+  "boards": [
+    {
+      "board": "arduino:sam:arduino_due_x",
+      "sketches": [
+        {
+          "name": "examples/MIDIUSB_clock",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 524288,
+              "current": {
+                "absolute": 11792,
+                "relative": 2.25
+              },
+              "previous": {
+                "absolute": 11792,
+                "relative": 2.25
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "previous": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "delta": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 5
+            },
+            "previous": {
+              "absolute": 5
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_loop",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 524288,
+              "current": {
+                "absolute": 11640,
+                "relative": 2.22
+              },
+              "previous": {
+                "absolute": 11640,
+                "relative": 2.22
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "previous": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "delta": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 6
+            },
+            "previous": {
+              "absolute": 6
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_read",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 524288,
+              "current": {
+                "absolute": 11808,
+                "relative": 2.25
+              },
+              "previous": {
+                "absolute": 11808,
+                "relative": 2.25
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "previous": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "delta": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 6
+            },
+            "previous": {
+              "absolute": 6
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_write",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 524288,
+              "current": {
+                "absolute": 11680,
+                "relative": 2.23
+              },
+              "previous": {
+                "absolute": 11680,
+                "relative": 2.23
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "previous": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "delta": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 6
+            },
+            "previous": {
+              "absolute": 6
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        }
+      ],
+      "sizes": [
+        {
+          "name": "flash",
+          "maximum": 524288,
+          "delta": {
+            "absolute": {
+              "minimum": 0,
+              "maximum": 0
+            },
+            "relative": {
+              "minimum": 0.0,
+              "maximum": 0.0
+            }
+          }
+        },
+        {
+          "name": "RAM for global variables",
+          "maximum": "N/A",
+          "delta": {
+            "absolute": {
+              "minimum": "N/A",
+              "maximum": "N/A"
+            },
+            "relative": {
+              "minimum": "N/A",
+              "maximum": "N/A"
+            }
+          }
+        }
+      ],
+      "warnings": {
+        "delta": {
+          "absolute": {
+            "minimum": 0,
+            "maximum": 0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/.github/workflows/testdata/artifact-source/per-report-artifact/arduino-samd-mkrzero.json
+++ b/.github/workflows/testdata/artifact-source/per-report-artifact/arduino-samd-mkrzero.json
@@ -1,0 +1,245 @@
+{
+  "commit_hash": "0123456789abcdef0123456789abcdef01234567",
+  "commit_url": "https://github.com/per1234/generate-size-deltas-report/commit/651f05f4d4aca30ac359e972c01568f873112d43",
+  "boards": [
+    {
+      "board": "arduino:samd:mkrzero",
+      "sketches": [
+        {
+          "name": "examples/MIDIUSB_clock",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 262144,
+              "current": {
+                "absolute": 11976,
+                "relative": 4.57
+              },
+              "previous": {
+                "absolute": 11892,
+                "relative": 4.54
+              },
+              "delta": {
+                "absolute": 84,
+                "relative": 0.03
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 32768,
+              "current": {
+                "absolute": 2300,
+                "relative": 7.02
+              },
+              "previous": {
+                "absolute": 2300,
+                "relative": 7.02
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 3
+            },
+            "previous": {
+              "absolute": 3
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_loop",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 262144,
+              "current": {
+                "absolute": 11784,
+                "relative": 4.5
+              },
+              "previous": {
+                "absolute": 11784,
+                "relative": 4.5
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 32768,
+              "current": {
+                "absolute": 2296,
+                "relative": 7.01
+              },
+              "previous": {
+                "absolute": 2296,
+                "relative": 7.01
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 4
+            },
+            "previous": {
+              "absolute": 4
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_read",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 262144,
+              "current": {
+                "absolute": 11940,
+                "relative": 4.55
+              },
+              "previous": {
+                "absolute": 11968,
+                "relative": 4.57
+              },
+              "delta": {
+                "absolute": -28,
+                "relative": -0.01
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 32768,
+              "current": {
+                "absolute": 2296,
+                "relative": 7.01
+              },
+              "previous": {
+                "absolute": 2296,
+                "relative": 7.01
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 4
+            },
+            "previous": {
+              "absolute": 4
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_write",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 262144,
+              "current": {
+                "absolute": 11808,
+                "relative": 4.5
+              },
+              "previous": {
+                "absolute": 11808,
+                "relative": 4.5
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 32768,
+              "current": {
+                "absolute": 2064,
+                "relative": 6.3
+              },
+              "previous": {
+                "absolute": 2032,
+                "relative": 6.2
+              },
+              "delta": {
+                "absolute": 32,
+                "relative": 0.1
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 4
+            },
+            "previous": {
+              "absolute": 4
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        }
+      ],
+      "sizes": [
+        {
+          "name": "flash",
+          "maximum": 262144,
+          "delta": {
+            "absolute": {
+              "minimum": -28,
+              "maximum": 84
+            },
+            "relative": {
+              "minimum": -0.01,
+              "maximum": 0.03
+            }
+          }
+        },
+        {
+          "name": "RAM for global variables",
+          "maximum": 32768,
+          "delta": {
+            "absolute": {
+              "minimum": 0,
+              "maximum": 32
+            },
+            "relative": {
+              "minimum": 0.0,
+              "maximum": 0.1
+            }
+          }
+        }
+      ],
+      "warnings": {
+        "delta": {
+          "absolute": {
+            "minimum": 0,
+            "maximum": 0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/.github/workflows/upload-report-artifact.yml
+++ b/.github/workflows/upload-report-artifact.yml
@@ -1,0 +1,39 @@
+name: Upload test sketches report artifact
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      # The "labeled" event can be used to easily retrigger the workflow to restore the workflow artifact after it
+      # expires every 90 days.
+      - labeled
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # The action only does a deltas report when the sketches report's `commit_hash` value matches the PR head SHA
+      - name: Update commit hash in reports
+        run: |
+          # Set up dedicated folder for the updated sketches reports (it's not possible to modify them in place)
+          SKETCHES_REPORTS_PATH="${{ runner.temp }}/sketches-reports"
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "SKETCHES_REPORTS_PATH=$SKETCHES_REPORTS_PATH" >> "$GITHUB_ENV"
+          mkdir --parents "$SKETCHES_REPORTS_PATH"
+
+          cd "${{ github.workspace }}/.github/workflows/testdata/sketches-reports/"
+          for reportFile in *.json; do
+            jq '.commit_hash = "${{ github.event.pull_request.head.sha }}"' "$reportFile" > "${SKETCHES_REPORTS_PATH}/$reportFile"
+          done
+
+      - name: Save sketches report as workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-reports

--- a/.github/workflows/upload-report-artifact.yml
+++ b/.github/workflows/upload-report-artifact.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # The action only does a deltas report when the sketches report's `commit_hash` value matches the PR head SHA
       - name: Update commit hash in reports
@@ -32,7 +32,7 @@ jobs:
           done
 
       - name: Save sketches report as workflow artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/upload-report-artifact.yml
+++ b/.github/workflows/upload-report-artifact.yml
@@ -13,6 +13,20 @@ jobs:
   upload:
     runs-on: ubuntu-latest
 
+    env:
+      ARTIFACT_NAME_PREFIX: sketches-report-
+
+    strategy:
+      fail-fast: false
+      matrix:
+        parameters:
+          # Coverage for pre-actions/upload-artifact@v4 approach where all reports are stored in a single artifact.
+          - artifact-name-suffix: multi
+            reports-folder: multi-report-artifact
+          # Coverage for actions/upload-artifact@v4 approach where each report is stored in a separate artifact.
+          - artifact-name-suffix: arduino-samd-mkrzero
+            reports-folder: per-report-artifact
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,7 +40,7 @@ jobs:
           echo "SKETCHES_REPORTS_PATH=$SKETCHES_REPORTS_PATH" >> "$GITHUB_ENV"
           mkdir --parents "$SKETCHES_REPORTS_PATH"
 
-          cd "${{ github.workspace }}/.github/workflows/testdata/sketches-reports/"
+          cd "${{ github.workspace }}/.github/workflows/testdata/artifact-source/${{ matrix.parameters.reports-folder }}"
           for reportFile in *.json; do
             jq '.commit_hash = "${{ github.event.pull_request.head.sha }}"' "$reportFile" > "${SKETCHES_REPORTS_PATH}/$reportFile"
           done
@@ -36,4 +50,4 @@ jobs:
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-          name: sketches-reports
+          name: ${{ env.ARTIFACT_NAME_PREFIX }}${{ matrix.parameters.artifact-name-suffix }}

--- a/.github/workflows/upload-report-artifact.yml
+++ b/.github/workflows/upload-report-artifact.yml
@@ -22,9 +22,11 @@ jobs:
         parameters:
           # Coverage for pre-actions/upload-artifact@v4 approach where all reports are stored in a single artifact.
           - artifact-name-suffix: multi
+            artifact-version: 1
             reports-folder: multi-report-artifact
           # Coverage for actions/upload-artifact@v4 approach where each report is stored in a separate artifact.
           - artifact-name-suffix: arduino-samd-mkrzero
+            artifact-version: 2
             reports-folder: per-report-artifact
 
     steps:
@@ -45,8 +47,19 @@ jobs:
             jq '.commit_hash = "${{ github.event.pull_request.head.sha }}"' "$reportFile" > "${SKETCHES_REPORTS_PATH}/$reportFile"
           done
 
-      - name: Save sketches report as workflow artifact
+      - name: Save sketches report as v1 format workflow artifact
+        if: matrix.parameters.artifact-version == '1'
+        # actions/upload-artifact 3.x is the last version to produce v1 format artifacts:
+        # https://github.com/actions/upload-artifact/blob/main/README.md#v4---whats-new
         uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.ARTIFACT_NAME_PREFIX }}${{ matrix.parameters.artifact-name-suffix }}
+
+      - name: Save sketches report as v2 format workflow artifact
+        if: matrix.parameters.artifact-version == '2'
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}


### PR DESCRIPTION
The sole purpose of this PR is to upload a "golden" sketches report artifact used in conjunction with [the integration test workflow](https://github.com/arduino/report-size-deltas/blob/main/.github/workflows/test-integration.yml) to get test size deltas reports in the comment thread in order to verify the functionality of the action.

The size deltas report should match the following:

---

**Memory usage change @ 2b51c9a4f37ef9dbb34415dfa24026981b2f6b4f**

Board|flash|%|RAM for global variables|%
-|-|-|-|-
`arduino:avr:leonardo`|:green_heart: -40 - 0|-0.14 - 0|:green_heart: -16 - 0|-0.62 - 0
`arduino:sam:arduino_due_x`|0 - 0|0 - 0|N/A|N/A
`arduino:samd:mkrzero`|:grey_question: -28 - +84|-0.01 - +0.03|:small_red_triangle: 0 - +32|0 - +0.1

<details>
<summary>Click for full report table</summary>

Board|`examples/MIDIUSB_clock`<br>flash|%|`examples/MIDIUSB_clock`<br>RAM for global variables|%|`examples/MIDIUSB_loop`<br>flash|%|`examples/MIDIUSB_loop`<br>RAM for global variables|%|`examples/MIDIUSB_read`<br>flash|%|`examples/MIDIUSB_read`<br>RAM for global variables|%|`examples/MIDIUSB_write`<br>flash|%|`examples/MIDIUSB_write`<br>RAM for global variables|%
-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-
`arduino:avr:leonardo`|0|0|0|0|0|0|0|0|0|0|0|0|-40|-0.14|-16|-0.62
`arduino:sam:arduino_due_x`|0|0|N/A|N/A|0|0|N/A|N/A|0|0|N/A|N/A|0|0|N/A|N/A
`arduino:samd:mkrzero`|84|0.03|0|0|0|0|0|0|-28|-0.01|0|0|0|0|32|0.1

</details>

<details>
<summary>Click for full report CSV</summary>

```
Board,examples/MIDIUSB_clock<br>flash,%,examples/MIDIUSB_clock<br>RAM for global variables,%,examples/MIDIUSB_loop<br>flash,%,examples/MIDIUSB_loop<br>RAM for global variables,%,examples/MIDIUSB_read<br>flash,%,examples/MIDIUSB_read<br>RAM for global variables,%,examples/MIDIUSB_write<br>flash,%,examples/MIDIUSB_write<br>RAM for global variables,%
arduino:avr:leonardo,0,0,0,0,0,0,0,0,0,0,0,0,-40,-0.14,-16,-0.62
arduino:sam:arduino_due_x,0,0,N/A,N/A,0,0,N/A,N/A,0,0,N/A,N/A,0,0,N/A,N/A
arduino:samd:mkrzero,84,0.03,0,0,0,0,0,0,-28,-0.01,0,0,0,0,32,0.1
```
</details>