### PR TITLE
Use Python 3.9.4 in CI and Docker container

### DIFF
--- a/.github/workflows/libraries_report-size-deltas.yml
+++ b/.github/workflows/libraries_report-size-deltas.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: '3.8.6'
+          python-version: '3.9.4'
 
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.6
+FROM python:3.9.4
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY reportsizedeltas /reportsizedeltas


### PR DESCRIPTION
The 	`actions/setup-python` action used to install Python for use in the CI workflows no longer offers Python 3.8.6,
which caused the CI to fail.

The action should use the same version of Python it's tested with, so I have also updated the action's Docker image to
`python:3.9.4`.