### PR TITLE
Bump codecov/codecov-action to v2

### DIFF
--- a/.github/workflows/libraries_report-size-deltas.yml
+++ b/.github/workflows/libraries_report-size-deltas.yml
@@ -51,7 +51,7 @@ jobs:
         run: coverage report
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           file: ${{ env.COVERAGE_DATA_FILENAME }}
           fail_ci_if_error: true

--- a/.github/workflows/libraries_report-size-deltas.yml
+++ b/.github/workflows/libraries_report-size-deltas.yml
@@ -39,12 +39,13 @@ jobs:
           pip install --quiet pep8-naming
           flake8 --config "${{ env.PYTHON_PROJECT_PATH }}/.flake8" --show-source "${{ env.PYTHON_PROJECT_PATH }}"
 
-      - name: Run Python unit tests and report code coverage
+      - name: Run Python unit tests and record code coverage data
         run: |
           export PYTHONPATH="${{ env.PYTHON_PROJECT_PATH }}"
           coverage run --source="${{ env.PYTHON_PROJECT_PATH }}" --module pytest "${{ env.PYTHON_PROJECT_TESTS_PATH }}"
-          # Display code coverage report in workflow run log
-          coverage report
+
+      - name: Display code coverage report
+        run: coverage report
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/libraries_report-size-deltas.yml
+++ b/.github/workflows/libraries_report-size-deltas.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       PYTHON_PROJECT_PATH: ${GITHUB_WORKSPACE}/reportsizedeltas
       PYTHON_PROJECT_TESTS_PATH: ${GITHUB_WORKSPACE}/reportsizedeltas/tests
+      COVERAGE_DATA_FILENAME: coverage.xml
 
     steps:
       - name: Checkout
@@ -43,6 +44,8 @@ jobs:
         run: |
           export PYTHONPATH="${{ env.PYTHON_PROJECT_PATH }}"
           coverage run --source="${{ env.PYTHON_PROJECT_PATH }}" --module pytest "${{ env.PYTHON_PROJECT_TESTS_PATH }}"
+          # Generate coverage data file for consumption by `codecov/codecov-action`.
+          coverage xml -o "${{ github.workspace }}/${{ env.COVERAGE_DATA_FILENAME }}"
 
       - name: Display code coverage report
         run: coverage report
@@ -50,4 +53,5 @@ jobs:
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1
         with:
+          file: ${{ env.COVERAGE_DATA_FILENAME }}
           fail_ci_if_error: true


### PR DESCRIPTION
The `codecov/codecov-action` GitHub Actions action is used in the "libraries/report-size-deltas workflow" workflow to upload code coverage data to Codecov.

The previously used `codecov/codecov-action@v1` version is deprecated and will cease working in less than a month:
https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1

The use of the `v2` major version ref will cause the workflow to use a stable version of the action, while also benefiting from ongoing development to the action up until such time as a new major release of an action is made. At that time we would need to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before manually updating the major ref (e.g., uses: `codecov/codecov-action@v3`).

---

The v1 version of the `codecov/codecov-action` action automatically generated the data file via `coverage xml`, but the
latest v2 does not, which causes it to fail:

```
[2022-01-05T09:53:02.481Z] ['info'] Searching for coverage files...
[2022-01-05T09:53:02.501Z] ['error'] There was an error running the uploader: Error while cleaning paths. No paths matched existing files!
Error: Codecov: Failed to properly upload: The process '/home/runner/work/_actions/codecov/codecov-action/v2.1.0/dist/codecov' failed with exit code 255
```

It also seems better to have full control over the process by doing it explicitly rather than relying on an action which
is used primarily to handle the data upload to Codecov.

This also more closely aligns the workflow with [the one for the `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches/blob/main/.github/workflows/test-python.yml).

---

Supersedes https://github.com/arduino/report-size-deltas/pull/17