### PR TITLE
Configure Dependabot to check for outdated Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,10 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+
+  - package-ecosystem: pip
+    directory: reportsizedeltas/tests
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/dependabot/README.md
   # See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: github-actions
+    assignees:
+      - per1234
     directory: / # Check the repository's workflows under /.github/workflows/
     schedule:
       interval: daily
@@ -13,6 +15,8 @@ updates:
       - "topic: infrastructure"
 
   - package-ecosystem: pip
+    assignees:
+      - per1234
     directory: reportsizedeltas/tests
     schedule:
       interval: daily


### PR DESCRIPTION
[**Dependabot**](https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) will periodically check all Python dependencies of the project. If any are found to be outdated, it will submit a pull request to update them.