### PR TITLE
Ignore failed integration test workflow job for Dependabot PRs

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -33,12 +33,16 @@ jobs:
       - name: Run action
         # Use arduino/report-size-deltas action from local path
         uses: ./
-        # The action will always fail on PRs submitted from forks due to not having write permissions.
+        # The action will always fail on PRs submitted from forks or by Dependabot due to not having write permissions.
         # Some verification can still be achieved by checking the log to see whether it failed in the expected manner:
         # WARNING:__main__:Temporarily unable to open URL (HTTP Error 403: Forbidden), retrying
         # ...
         # TimeoutError: Maximum number of URL load retries exceeded
-        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        continue-on-error: >-
+          ${{
+            github.event.pull_request.head.repo.full_name != github.repository ||
+            github.triggering_actor == 'dependabot[bot]'
+          }}
         with:
           sketches-reports-source: .github/workflows/testdata/sketches-reports
 
@@ -50,5 +54,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run action
+        # The action will always fail on pushes by Dependabot due to not having write permissions.
+        # Rather than skipping the job under these conditions, the failure is ignored because some verification can
+        # still be achieved by checking the log to see whether it failed in the expected manner:
+        # WARNING:__main__:Temporarily unable to open URL (HTTP Error 403: Forbidden), retrying
+        # ...
+        # TimeoutError: Maximum number of URL load retries exceeded
+        continue-on-error: ${{ github.triggering_actor == 'dependabot[bot]' }}
         # Use arduino/report-size-deltas action from local path
         uses: ./


### PR DESCRIPTION
The integration test workflow requires the [`GITHUB_TOKEN` token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) to have write permissions in order to make the deltas report comment.

Because the token only has [read permissions when the workflow is triggered by a PR from a fork](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), the job is [configured to pass](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) even though the action run step fails (it is intentionally run instead of being skipped because it can still provide some validation even if it is expected to fail).

Currently the workflow is configured to require the step to pass when a PR is submitted from a local branch, since the token [has write permissions in that case](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token). However, there is one exception: when the PR is submitted by [**Dependabot**](https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates), the [token permissions are downgraded](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token:~:text=Workflow%20runs%20triggered%20by%20Dependabot%20pull%20requests).

So the workflow must be configured to treat the PRs from Dependabot in the same manner as PRs from forks