### PR TITLE
Handle sketches reports with missing size data

### DIFF
--- a/reportsizedeltas/reportsizedeltas.py
+++ b/reportsizedeltas/reportsizedeltas.py
@@ -36,7 +36,7 @@ def set_verbosity(enable_verbosity):
     """Turn debug output on or off.
 
     Keyword arguments:
-    enable_verbosity -- this will generally be controlled via the script's --verbose command line argument
+    enable_verbosity -- enable/disable verbose output
                               (True, False)
     """
     # DEBUG: automatically generated output and all higher log level output
@@ -123,9 +123,9 @@ class ReportSizeDeltas:
                 pr_number = pr_data["number"]
                 pr_head_sha = pr_data["head"]["sha"]
                 print("::debug::Processing pull request number:", pr_number)
-                # When a PR is locked, only collaborators may comment. The automatically generated GITHUB_TOKEN will
-                # likely be used, which is owned by the github-actions bot, who doesn't have collaborator status. So
-                # locking the thread would cause the job to fail.
+                # When a PR is locked, only collaborators may comment. The automatically generated GITHUB_TOKEN owned by
+                # the github-actions bot will likely be used. The bot doesn't have collaborator status so it will
+                # generally be impossible to make reports on locked PRs.
                 if pr_data["locked"]:
                     print("::debug::PR locked, skipping")
                     continue
@@ -280,7 +280,7 @@ class ReportSizeDeltas:
         """Parse the artifact files and return a list containing the data.
 
         Keyword arguments:
-        artifact_folder_object -- object containing the data about the temporary folder that stores the markdown files
+        artifact_folder_object -- object containing the data about the temporary folder that stores the Markdown files
         """
         with artifact_folder_object as artifact_folder:
             # artifact_folder will be a string when running in non-local report mode
@@ -317,7 +317,7 @@ class ReportSizeDeltas:
         """Return the Markdown for the deltas report comment.
 
         Keyword arguments:
-        sketches_reports -- list of sketches_reports containing the data to generate the deltas report from
+        sketches_reports -- list of sketches reports containing the data to generate the deltas report from
         """
         # From https://github.community/t/maximum-length-for-the-comment-body-in-issues-and-pr/148867/2
         # > PR body/Issue comments are still stored in MySQL as a mediumblob with a maximum value length of 262,144.
@@ -466,7 +466,7 @@ class ReportSizeDeltas:
         Keyword arguments:
         show_emoji -- whether to add the emoji change indicator
         minimum -- minimum amount of change for this memory type
-        minimum -- maximum amount of change for this memory type
+        maximum -- maximum amount of change for this memory type
         """
         size_decrease_emoji = ":green_heart:"
         size_ambiguous_emoji = ":grey_question:"
@@ -550,7 +550,7 @@ class ReportSizeDeltas:
             except json.decoder.JSONDecodeError as exception:
                 # Output some information on the exception
                 logger.warning(str(exception.__class__.__name__) + ": " + str(exception))
-                # pass on the exception to the caller
+                # Pass the exception on to the caller
                 raise exception
 
             if not json_data:
@@ -722,13 +722,13 @@ def get_report_column_number(report, column_heading):
         # Absolute column
         # Add the heading
         report[0].append(column_heading)
-        # Expand the size of the last (current) row to match the new number of columns
+        # Expand the size of the final row (the current row) to match the new number of columns
         report[len(report) - 1].append("")
 
         # Relative column
         # Add the heading
         report[0].append(relative_column_heading)
-        # Expand the size of the last (current) row to match the new number of columns
+        # Expand the size of the final row (the current row) to match the new number of columns
         report[len(report) - 1].append("")
 
     return column_number

--- a/reportsizedeltas/reportsizedeltas.py
+++ b/reportsizedeltas/reportsizedeltas.py
@@ -291,6 +291,8 @@ class ReportSizeDeltas:
                     report_data = json.load(report_file)
                     if (
                         (self.ReportKeys.boards not in report_data)
+                        or (self.ReportKeys.sizes
+                            not in report_data[self.ReportKeys.boards][0])
                         or (self.ReportKeys.maximum
                             not in report_data[self.ReportKeys.boards][0][self.ReportKeys.sizes][0])
                     ):

--- a/reportsizedeltas/reportsizedeltas.py
+++ b/reportsizedeltas/reportsizedeltas.py
@@ -328,105 +328,15 @@ class ReportSizeDeltas:
 
         # Generate summary report data
         summary_report_data = [[fqbn_column_heading]]
-        row_number = 0
         for fqbns_data in sketches_reports:
             for fqbn_data in fqbns_data[self.ReportKeys.boards]:
-                row_number += 1
-                # Add a row to the report
-                row = ["" for _ in range(len(summary_report_data[0]))]
-                row[0] = fqbn_data[self.ReportKeys.board]
-                summary_report_data.append(row)
-
-                # Populate the row with data
-                for size_data in fqbn_data[self.ReportKeys.sizes]:
-                    # Determine column number for this memory type
-                    column_number = get_report_column_number(
-                        report=summary_report_data,
-                        column_heading=size_data[self.ReportKeys.name]
-                    )
-
-                    # Add the memory data to the cell
-                    if self.ReportKeys.delta in size_data:
-                        # Absolute data
-                        summary_report_data[row_number][column_number] = (
-                            self.get_summary_value(
-                                show_emoji=True,
-                                minimum=size_data[self.ReportKeys.delta][self.ReportKeys.absolute][
-                                    self.ReportKeys.minimum],
-                                maximum=size_data[self.ReportKeys.delta][self.ReportKeys.absolute][
-                                    self.ReportKeys.maximum]
-                            )
-                        )
-
-                        # Relative data
-                        summary_report_data[row_number][column_number + 1] = (
-                            self.get_summary_value(
-                                show_emoji=False,
-                                minimum=size_data[self.ReportKeys.delta][self.ReportKeys.relative][
-                                    self.ReportKeys.minimum],
-                                maximum=size_data[self.ReportKeys.delta][self.ReportKeys.relative][
-                                    self.ReportKeys.maximum]
-                            )
-                        )
-                    else:
-                        # Absolute data
-                        summary_report_data[row_number][column_number] = (
-                            self.get_summary_value(
-                                show_emoji=True,
-                                minimum=self.not_applicable_indicator,
-                                maximum=self.not_applicable_indicator
-                            )
-                        )
-
-                        # Relative data
-                        summary_report_data[row_number][column_number + 1] = (
-                            self.get_summary_value(
-                                show_emoji=False,
-                                minimum=self.not_applicable_indicator,
-                                maximum=self.not_applicable_indicator
-                            )
-                        )
+                self.add_summary_report_row(summary_report_data, fqbn_data)
 
         # Generate detailed report data
         full_report_data = [[fqbn_column_heading]]
-        row_number = 0
         for fqbns_data in sketches_reports:
             for fqbn_data in fqbns_data[self.ReportKeys.boards]:
-                row_number += 1
-                # Add a row to the report
-                row = ["" for _ in range(len(full_report_data[0]))]
-                row[0] = fqbn_data[self.ReportKeys.board]
-                full_report_data.append(row)
-
-                # Populate the row with data
-                for sketch in fqbn_data[self.ReportKeys.sketches]:
-                    for size_data in sketch[self.ReportKeys.sizes]:
-                        # Determine column number for this memory type
-                        column_number = get_report_column_number(
-                            report=full_report_data,
-                            column_heading=(
-                                sketch[self.ReportKeys.name] + "<br>"
-                                + size_data[self.ReportKeys.name]
-                            )
-                        )
-
-                        # Add the memory data to the cell
-                        if self.ReportKeys.delta in size_data:
-                            # Absolute
-                            full_report_data[row_number][column_number] = (
-                                size_data[self.ReportKeys.delta][self.ReportKeys.absolute]
-                            )
-
-                            # Relative
-                            full_report_data[row_number][column_number + 1] = (
-                                size_data[self.ReportKeys.delta][self.ReportKeys.relative]
-                            )
-                        else:
-                            # Absolute
-                            full_report_data[row_number][column_number] = self.not_applicable_indicator
-
-                            # Relative
-                            full_report_data[row_number][column_number + 1] = self.not_applicable_indicator
+                self.add_detailed_report_row(full_report_data, fqbn_data)
 
         # Add comment heading
         report_markdown = self.report_key_beginning + sketches_reports[0][self.ReportKeys.commit_hash] + "**\n\n"
@@ -459,6 +369,112 @@ class ReportSizeDeltas:
 
         logger.debug("Report:\n" + report_markdown)
         return report_markdown
+
+    def add_summary_report_row(self, report_data, fqbn_data):
+        """Add a row to the summary report.
+
+        Keyword arguments:
+        report_data -- the report to add the row to
+        right_directory -- the data used to populate the row
+        """
+        row_number = len(report_data)
+        # Add a row to the report
+        row = ["" for _ in range(len(report_data[0]))]
+        row[0] = fqbn_data[self.ReportKeys.board]
+        report_data.append(row)
+
+        # Populate the row with data
+        for size_data in fqbn_data[self.ReportKeys.sizes]:
+            # Determine column number for this memory type
+            column_number = get_report_column_number(
+                report=report_data,
+                column_heading=size_data[self.ReportKeys.name]
+            )
+
+            # Add the memory data to the cell
+            if self.ReportKeys.delta in size_data:
+                # Absolute data
+                report_data[row_number][column_number] = (
+                    self.get_summary_value(
+                        show_emoji=True,
+                        minimum=size_data[self.ReportKeys.delta][self.ReportKeys.absolute][
+                            self.ReportKeys.minimum],
+                        maximum=size_data[self.ReportKeys.delta][self.ReportKeys.absolute][
+                            self.ReportKeys.maximum]
+                    )
+                )
+
+                # Relative data
+                report_data[row_number][column_number + 1] = (
+                    self.get_summary_value(
+                        show_emoji=False,
+                        minimum=size_data[self.ReportKeys.delta][self.ReportKeys.relative][
+                            self.ReportKeys.minimum],
+                        maximum=size_data[self.ReportKeys.delta][self.ReportKeys.relative][
+                            self.ReportKeys.maximum]
+                    )
+                )
+            else:
+                # Absolute data
+                report_data[row_number][column_number] = (
+                    self.get_summary_value(
+                        show_emoji=True,
+                        minimum=self.not_applicable_indicator,
+                        maximum=self.not_applicable_indicator
+                    )
+                )
+
+                # Relative data
+                report_data[row_number][column_number + 1] = (
+                    self.get_summary_value(
+                        show_emoji=False,
+                        minimum=self.not_applicable_indicator,
+                        maximum=self.not_applicable_indicator
+                    )
+                )
+
+    def add_detailed_report_row(self, report_data, fqbn_data):
+        """Add a row to the detailed report.
+
+        Keyword arguments:
+        report_data -- the report to add the row to
+        right_directory -- the data used to populate the row
+        """
+        row_number = len(report_data)
+        # Add a row to the report
+        row = ["" for _ in range(len(report_data[0]))]
+        row[0] = fqbn_data[self.ReportKeys.board]
+        report_data.append(row)
+
+        # Populate the row with data
+        for sketch in fqbn_data[self.ReportKeys.sketches]:
+            for size_data in sketch[self.ReportKeys.sizes]:
+                # Determine column number for this memory type
+                column_number = get_report_column_number(
+                    report=report_data,
+                    column_heading=(
+                        sketch[self.ReportKeys.name] + "<br>"
+                        + size_data[self.ReportKeys.name]
+                    )
+                )
+
+                # Add the memory data to the cell
+                if self.ReportKeys.delta in size_data:
+                    # Absolute
+                    report_data[row_number][column_number] = (
+                        size_data[self.ReportKeys.delta][self.ReportKeys.absolute]
+                    )
+
+                    # Relative
+                    report_data[row_number][column_number + 1] = (
+                        size_data[self.ReportKeys.delta][self.ReportKeys.relative]
+                    )
+                else:
+                    # Absolute
+                    report_data[row_number][column_number] = self.not_applicable_indicator
+
+                    # Relative
+                    report_data[row_number][column_number + 1] = self.not_applicable_indicator
 
     def get_summary_value(self, show_emoji, minimum, maximum):
         """Return the Markdown formatted text for a memory change data cell in the report table.

--- a/reportsizedeltas/tests/data/size-deltas-reports-new/arduino-mbed_portenta-envie_m7.json
+++ b/reportsizedeltas/tests/data/size-deltas-reports-new/arduino-mbed_portenta-envie_m7.json
@@ -1,0 +1,65 @@
+{
+  "commit_hash": "54815a7d1a30fcb0d77d98242b158e7845c0516d",
+  "commit_url": "https://example.com/foo",
+  "boards": [
+    {
+      "board": "arduino:mbed_portenta:envie_m7",
+      "sketches": [
+        {
+          "name": "examples/Bar",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            }
+          ]
+        },
+        {
+          "name": "examples/Foo",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            }
+          ]
+        }
+      ],
+      "sizes": [
+        {
+          "name": "flash",
+          "maximum": "N/A"
+        },
+        {
+          "name": "RAM for global variables",
+          "maximum": "N/A"
+        }
+      ]
+    }
+  ]
+}

--- a/reportsizedeltas/tests/data/size-deltas-reports-old/arduino-mbed_portenta-envie_m7.json
+++ b/reportsizedeltas/tests/data/size-deltas-reports-old/arduino-mbed_portenta-envie_m7.json
@@ -1,0 +1,55 @@
+{
+  "commit_hash": "54815a7d1a30fcb0d77d98242b158e7845c0516d",
+  "commit_url": "https://example.com/foo",
+  "boards": [
+    {
+      "board": "arduino:mbed_portenta:envie_m7",
+      "sketches": [
+        {
+          "name": "examples/Bar",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            }
+          ]
+        },
+        {
+          "name": "examples/Foo",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/reportsizedeltas/tests/test_reportsizedeltas.py
+++ b/reportsizedeltas/tests/test_reportsizedeltas.py
@@ -812,6 +812,200 @@ def test_get_sketches_reports(sketches_reports_path, expected_sketches_reports):
     assert sketches_reports == expected_sketches_reports
 
 
+@pytest.mark.parametrize(
+    "report_data, fqbn_data, expected_report_data",
+    [
+        (
+            [["Board"]],
+            {
+                report_keys.board: "arduino:avr:uno",
+                report_keys.sizes: [
+                    {
+                        report_keys.delta: {
+                            report_keys.absolute: {
+                                report_keys.maximum: -994,
+                                report_keys.minimum: -994
+                            },
+                            report_keys.relative: {
+                                report_keys.maximum: -3.08,
+                                report_keys.minimum: -3.08
+                            }
+                        },
+                        report_keys.name: "flash",
+                        report_keys.maximum: 32256,
+                    },
+                    {
+                        report_keys.delta: {
+                            report_keys.absolute: {
+                                report_keys.maximum: -175,
+                                report_keys.minimum: -175
+                            },
+                            report_keys.relative: {
+                                report_keys.maximum: -8.54,
+                                report_keys.minimum: -8.54
+                            }
+                        },
+                        report_keys.name: "RAM for global variables",
+                        report_keys.maximum: 2048,
+                    }
+                ]
+            },
+            [
+                ["Board", "flash", "%", "RAM for global variables", "%"],
+                [
+                    "arduino:avr:uno",
+                    ":green_heart: -994 - -994",
+                    "-3.08 - -3.08",
+                    ":green_heart: -175 - -175",
+                    "-8.54 - -8.54"
+                ]
+            ]
+        ),
+        (
+            [
+                ["Board", "flash", "%", "RAM for global variables", "%"],
+                [
+                    "arduino:avr:uno",
+                    ":green_heart: -994 - -994",
+                    "-3.08 - -3.08",
+                    ":green_heart: -175 - -175",
+                    "-8.54 - -8.54"
+                ]
+            ],
+            {
+                report_keys.board: "arduino:mbed_portenta:envie_m7",
+                report_keys.sizes: [
+                    {
+                        report_keys.name: "flash",
+                        report_keys.maximum: "N/A",
+                    },
+                    {
+                        report_keys.name: "RAM for global variables",
+                        report_keys.maximum: "N/A",
+                    }
+                ]
+            },
+            [
+                ["Board", "flash", "%", "RAM for global variables", "%"],
+                [
+                    "arduino:avr:uno",
+                    ":green_heart: -994 - -994",
+                    "-3.08 - -3.08",
+                    ":green_heart: -175 - -175",
+                    "-8.54 - -8.54"
+                ],
+                ["arduino:mbed_portenta:envie_m7", "N/A", "N/A", "N/A", "N/A"]
+            ]
+        )
+    ]
+)
+def test_add_summary_report_row(report_data, fqbn_data, expected_report_data):
+    report_size_deltas = get_reportsizedeltas_object()
+    report_size_deltas.add_summary_report_row(report_data, fqbn_data)
+
+    assert report_data == expected_report_data
+
+
+@pytest.mark.parametrize(
+    "report_data, fqbn_data, expected_report_data",
+    [
+        (
+            [["Board"]],
+            {
+                report_keys.board: "arduino:avr:leonardo",
+                report_keys.sketches: [
+                    {
+                        report_keys.compilation_success: True,
+                        report_keys.name: "examples/Foo",
+                        report_keys.sizes: [
+                            {
+                                report_keys.current: {
+                                    report_keys.absolute: 3462,
+                                    report_keys.relative: 12.07
+                                },
+                                report_keys.delta: {
+                                    report_keys.absolute: -12,
+                                    report_keys.relative: -0.05
+                                },
+                                report_keys.name: "flash",
+                                report_keys.maximum: 28672,
+                                report_keys.previous: {
+                                    report_keys.absolute: 3474,
+                                    report_keys.relative: 12.12
+                                }
+                            },
+                            {
+                                report_keys.current: {
+                                    report_keys.absolute: 149,
+                                    report_keys.relative: 5.82
+                                },
+                                report_keys.delta: {
+                                    report_keys.absolute: 0,
+                                    report_keys.relative: -0.00
+                                },
+                                report_keys.name: "RAM for global variables",
+                                report_keys.maximum: 2560,
+                                report_keys.previous: {
+                                    report_keys.absolute: 149,
+                                    report_keys.relative: 5.82
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            [
+                ["Board", "examples/Foo<br>flash", "%", "examples/Foo<br>RAM for global variables", "%"],
+                ["arduino:avr:leonardo", -12, -0.05, 0, -0.0]
+            ]
+        ),
+        (
+            [
+                ["Board", "examples/Foo<br>flash", "%", "examples/Foo<br>RAM for global variables", "%"],
+                ["arduino:avr:leonardo", -12, -0.05, 0, -0.0]
+            ],
+            {
+                report_keys.board: "arduino:mbed_portenta:envie_m7",
+                report_keys.sketches: [
+                    {
+                        report_keys.compilation_success: True,
+                        report_keys.name: "examples/Foo",
+                        report_keys.sizes: [
+                            {
+                                report_keys.current: {
+                                    report_keys.absolute: "N/A",
+                                    report_keys.relative: "N/A"
+                                },
+                                report_keys.name: "flash",
+                                report_keys.maximum: "N/A",
+                            },
+                            {
+                                report_keys.current: {
+                                    report_keys.absolute: "N/A",
+                                    report_keys.relative: "N/A"
+                                },
+                                report_keys.name: "RAM for global variables",
+                                report_keys.maximum: "N/A",
+                            }
+                        ]
+                    }
+                ]
+            },
+            [
+                ["Board", "examples/Foo<br>flash", "%", "examples/Foo<br>RAM for global variables", "%"],
+                ["arduino:avr:leonardo", -12, -0.05, 0, -0.0],
+                ["arduino:mbed_portenta:envie_m7", "N/A", "N/A", "N/A", "N/A"]
+            ]
+        )
+    ]
+)
+def test_add_detailed_report_row(report_data, fqbn_data, expected_report_data):
+    report_size_deltas = get_reportsizedeltas_object()
+    report_size_deltas.add_detailed_report_row(report_data, fqbn_data)
+
+    assert report_data == expected_report_data
+
+
 def test_generate_report():
     sketches_report_path = test_data_path.joinpath("size-deltas-reports-new")
     expected_deltas_report = (


### PR DESCRIPTION
Previously, the action's code assumed that the sketches reports [artifacts](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts) would always contain size deltas data. If a report was present that did not contain this data, the action would fail with a `KeyError` error for keys missing from the report.

For example:

```text
Traceback (most recent call last):
  File "/reportsizedeltas/reportsizedeltas.py", line 737, in <module>
    main()  # pragma: no cover
  File "/reportsizedeltas/reportsizedeltas.py", line 32, in main
    report_size_deltas.report_size_deltas()
  File "/reportsizedeltas/reportsizedeltas.py", line 95, in report_size_deltas
    self.report_size_deltas_from_workflow_artifacts()
  File "/reportsizedeltas/reportsizedeltas.py", line 149, in report_size_deltas_from_workflow_artifacts
    sketches_reports = self.get_sketches_reports(artifact_folder_object=artifact_folder_object)
  File "/reportsizedeltas/reportsizedeltas.py", line 295, in get_sketches_reports
    not in report_data[self.ReportKeys.boards][0][self.ReportKeys.sizes][0])
KeyError: 'sizes'
```


The most common cause of a compilation not producing size data is a compilation error. In this case the default **arduino/compile-sketches** workflow configuration would not upload a sketches report workflow artifact (because the upload is done in a subsequent step and GitHub Actions exits the job immediately when a step fails) so the **arduino/report-size-deltas** action's inability to handle the resulting report format was only an issue in unusual workflow configurations.

There is another cause of a compilation not producing size data: the boards platform was not [configured to produce the data](https://arduino.github.io/arduino-cli/dev/platform-specification/#recipes-to-compute-binary-sketch-size). Previously, all known Arduino boards platforms produced at least some size data so the problem of the action's lack of compatibility with these boards was only hypothetical. However, [the "**Arduino Mbed OS Portenta Boards**" platform](https://github.com/arduino/ArduinoCore-mbed) now contains two boards which are missing the configuration to produce the size data:

- Portenta H7 (https://github.com/arduino/ArduinoCore-mbed/issues/642)
- Portenta X8

This meant that the action is broken by any sketches reports produced by compiling for either of those boards.

One possible fix would be to make the **arduino/compile-sketches** action add all expected objects to the sketches report even when the compilation does not produce any data to populated them with. But this seems like the wrong approach. So the alternative approach was taken of making the arduino/report-size-deltas action check for the presence of the data. If it is not present, a "N/A" is added to the report in place of the data.
