### PR TITLE
Prevent unintended rendering of report content

### DIFF
--- a/reportsizedeltas/reportsizedeltas.py
+++ b/reportsizedeltas/reportsizedeltas.py
@@ -380,7 +380,7 @@ class ReportSizeDeltas:
         row_number = len(report_data)
         # Add a row to the report
         row = ["" for _ in range(len(report_data[0]))]
-        row[0] = fqbn_data[self.ReportKeys.board]
+        row[0] = "`{board_name}`".format(board_name=fqbn_data[self.ReportKeys.board])
         report_data.append(row)
 
         # Populate the row with data
@@ -443,7 +443,7 @@ class ReportSizeDeltas:
         row_number = len(report_data)
         # Add a row to the report
         row = ["" for _ in range(len(report_data[0]))]
-        row[0] = fqbn_data[self.ReportKeys.board]
+        row[0] = "`{board_name}`".format(board_name=fqbn_data[self.ReportKeys.board])
         report_data.append(row)
 
         # Populate the row with data
@@ -453,8 +453,10 @@ class ReportSizeDeltas:
                 column_number = get_report_column_number(
                     report=report_data,
                     column_heading=(
-                        sketch[self.ReportKeys.name] + "<br>"
-                        + size_data[self.ReportKeys.name]
+                        "`{sketch_name}`<br>{size_name}".format(
+                            sketch_name=sketch[self.ReportKeys.name],
+                            size_name=size_data[self.ReportKeys.name]
+                        )
                     )
                 )
 
@@ -776,7 +778,16 @@ def generate_csv_table(row_list):
     csv_string = io.StringIO()
     csv_writer = csv.writer(csv_string, lineterminator="\n")
     for row in row_list:
-        csv_writer.writerow(row)
+        cleaned_row = []
+        for cell in row:
+            cleaned_cell = cell
+            if isinstance(cleaned_cell, str):
+                # The "code span" markup is not needed in the CSV report.
+                cleaned_cell = cleaned_cell.replace("`", "")
+
+            cleaned_row.append(cleaned_cell)
+
+        csv_writer.writerow(cleaned_row)
 
     return csv_string.getvalue()
 

--- a/reportsizedeltas/tests/test_reportsizedeltas.py
+++ b/reportsizedeltas/tests/test_reportsizedeltas.py
@@ -853,7 +853,7 @@ def test_get_sketches_reports(sketches_reports_path, expected_sketches_reports):
             [
                 ["Board", "flash", "%", "RAM for global variables", "%"],
                 [
-                    "arduino:avr:uno",
+                    "`arduino:avr:uno`",
                     ":green_heart: -994 - -994",
                     "-3.08 - -3.08",
                     ":green_heart: -175 - -175",
@@ -865,7 +865,7 @@ def test_get_sketches_reports(sketches_reports_path, expected_sketches_reports):
             [
                 ["Board", "flash", "%", "RAM for global variables", "%"],
                 [
-                    "arduino:avr:uno",
+                    "`arduino:avr:uno`",
                     ":green_heart: -994 - -994",
                     "-3.08 - -3.08",
                     ":green_heart: -175 - -175",
@@ -888,13 +888,13 @@ def test_get_sketches_reports(sketches_reports_path, expected_sketches_reports):
             [
                 ["Board", "flash", "%", "RAM for global variables", "%"],
                 [
-                    "arduino:avr:uno",
+                    "`arduino:avr:uno`",
                     ":green_heart: -994 - -994",
                     "-3.08 - -3.08",
                     ":green_heart: -175 - -175",
                     "-8.54 - -8.54"
                 ],
-                ["arduino:mbed_portenta:envie_m7", "N/A", "N/A", "N/A", "N/A"]
+                ["`arduino:mbed_portenta:envie_m7`", "N/A", "N/A", "N/A", "N/A"]
             ]
         )
     ]
@@ -955,14 +955,14 @@ def test_add_summary_report_row(report_data, fqbn_data, expected_report_data):
                 ]
             },
             [
-                ["Board", "examples/Foo<br>flash", "%", "examples/Foo<br>RAM for global variables", "%"],
-                ["arduino:avr:leonardo", -12, -0.05, 0, -0.0]
+                ["Board", "`examples/Foo`<br>flash", "%", "`examples/Foo`<br>RAM for global variables", "%"],
+                ["`arduino:avr:leonardo`", -12, -0.05, 0, -0.0]
             ]
         ),
         (
             [
-                ["Board", "examples/Foo<br>flash", "%", "examples/Foo<br>RAM for global variables", "%"],
-                ["arduino:avr:leonardo", -12, -0.05, 0, -0.0]
+                ["Board", "`examples/Foo`<br>flash", "%", "`examples/Foo`<br>RAM for global variables", "%"],
+                ["`arduino:avr:leonardo`", -12, -0.05, 0, -0.0]
             ],
             {
                 report_keys.board: "arduino:mbed_portenta:envie_m7",
@@ -992,9 +992,9 @@ def test_add_summary_report_row(report_data, fqbn_data, expected_report_data):
                 ]
             },
             [
-                ["Board", "examples/Foo<br>flash", "%", "examples/Foo<br>RAM for global variables", "%"],
-                ["arduino:avr:leonardo", -12, -0.05, 0, -0.0],
-                ["arduino:mbed_portenta:envie_m7", "N/A", "N/A", "N/A", "N/A"]
+                ["Board", "`examples/Foo`<br>flash", "%", "`examples/Foo`<br>RAM for global variables", "%"],
+                ["`arduino:avr:leonardo`", -12, -0.05, 0, -0.0],
+                ["`arduino:mbed_portenta:envie_m7`", "N/A", "N/A", "N/A", "N/A"]
             ]
         )
     ]
@@ -1012,17 +1012,17 @@ def test_generate_report():
         "**Memory usage change @ d8fd302**\n\n"
         "Board|flash|%|RAM for global variables|%\n"
         "-|-|-|-|-\n"
-        "arduino:avr:leonardo|:green_heart: -12 - -12|-0.05 - -0.05|0 - 0|0.0 - 0.0\n"
-        "arduino:avr:uno|:green_heart: -994 - -994|-3.08 - -3.08|:green_heart: -175 - -175|-8.54 - -8.54\n"
-        "arduino:mbed_portenta:envie_m7|N/A|N/A|N/A|N/A\n\n"
+        "`arduino:avr:leonardo`|:green_heart: -12 - -12|-0.05 - -0.05|0 - 0|0.0 - 0.0\n"
+        "`arduino:avr:uno`|:green_heart: -994 - -994|-3.08 - -3.08|:green_heart: -175 - -175|-8.54 - -8.54\n"
+        "`arduino:mbed_portenta:envie_m7`|N/A|N/A|N/A|N/A\n\n"
         "<details>\n"
         "<summary>Click for full report table</summary>\n\n"
-        "Board|examples/Bar<br>flash|%|examples/Bar<br>RAM for global variables|%|examples/Foo<br>flash|%|examples/Foo"
-        "<br>RAM for global variables|%\n"
+        "Board|`examples/Bar`<br>flash|%|`examples/Bar`<br>RAM for global variables|%|`examples/Foo`<br>flash|%|"
+        "`examples/Foo`<br>RAM for global variables|%\n"
         "-|-|-|-|-|-|-|-|-\n"
-        "arduino:avr:leonardo|N/A|N/A|N/A|N/A|-12|-0.05|0|0.0\n"
-        "arduino:avr:uno|N/A|N/A|N/A|N/A|-994|-3.08|-175|-8.54\n"
-        "arduino:mbed_portenta:envie_m7|N/A|N/A|N/A|N/A|N/A|N/A|N/A|N/A\n\n"
+        "`arduino:avr:leonardo`|N/A|N/A|N/A|N/A|-12|-0.05|0|0.0\n"
+        "`arduino:avr:uno`|N/A|N/A|N/A|N/A|-994|-3.08|-175|-8.54\n"
+        "`arduino:mbed_portenta:envie_m7`|N/A|N/A|N/A|N/A|N/A|N/A|N/A|N/A\n\n"
         "</details>\n\n"
         "<details>\n"
         "<summary>Click for full report CSV</summary>\n\n"


### PR DESCRIPTION
The report is made in the form of GitHub PR comment. These comments are rendered according to the ["GitHub Flavored Markdown" markup language](https://github.github.com/gfm/).

In addition to the intentional markup used to format the report, the uncontrolled strings of the report content might contain incidental markup. Previously, this would cause the report to be rendered incorrectly.

For example, the FQBN `arduino:avr:mega:cpu=atmega2560` contains the `:mega:` markup for the :mega: emoji, so was rendered incorrectly:

> arduino:avr📣cpu=atmega2560

The solution is to wrap the uncontrolled strings in the Markdown ["code span" markup](https://github.github.com/gfm/#code-spans).

Since the entire CSV format report is already wrapped in the equivalent ["code fence" markup](https://github.github.com/gfm/#fenced-code-blocks), the introduction of this markup into that part of the report is unnecessary.