### PR TITLE
Bump action dependencies in "Upload test sketches report artifact" workflow

### DIFF
--- a/.github/workflows/upload-report-artifact.yml
+++ b/.github/workflows/upload-report-artifact.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # The action only does a deltas report when the sketches report's `commit_hash` value matches the PR head SHA
       - name: Update commit hash in reports
@@ -32,7 +32,7 @@ jobs:
           done
 
       - name: Save sketches report as workflow artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}


### PR DESCRIPTION
`actions/upload-artifact` is only bumped to v3 here because the 4.0.0 release of that action [introduces a significant change in the artifact format](https://github.com/actions/upload-artifact/releases/tag/v4.0.0#:~:text=Artifacts%20created%20with%20versions%20v3%20and%20below%20are%20not%20compatible%20with%20the%20v4%20actions.). It is necessary for the workflow to continue to produce test data that provides integration test coverage for compatibility of the action with the artifacts produced by <=v3 of the action.

The changes necessary to produce test data for coverage of compatibility with the artifacts produced by `actions/upload-artifact` >=v4 will be introduced in a separate PR.