### PR TITLE
Upload multiple test data artifacts to provide coverage for artifact name pattern feature

### DIFF
--- a/.github/workflows/testdata/artifact-source/multi-report-artifact/arduino-avr-leonardo.json
+++ b/.github/workflows/testdata/artifact-source/multi-report-artifact/arduino-avr-leonardo.json
@@ -1,0 +1,245 @@
+{
+  "commit_hash": "0123456789abcdef0123456789abcdef01234567",
+  "commit_url": "https://github.com/per1234/generate-size-deltas-report/commit/651f05f4d4aca30ac359e972c01568f873112d43",
+  "boards": [
+    {
+      "board": "arduino:avr:leonardo",
+      "sketches": [
+        {
+          "name": "examples/MIDIUSB_clock",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 28672,
+              "current": {
+                "absolute": 4792,
+                "relative": 16.71
+              },
+              "previous": {
+                "absolute": 4792,
+                "relative": 16.71
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 2560,
+              "current": {
+                "absolute": 443,
+                "relative": 17.3
+              },
+              "previous": {
+                "absolute": 443,
+                "relative": 17.3
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 2
+            },
+            "previous": {
+              "absolute": 2
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_loop",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 28672,
+              "current": {
+                "absolute": 4870,
+                "relative": 16.99
+              },
+              "previous": {
+                "absolute": 4870,
+                "relative": 16.99
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 2560,
+              "current": {
+                "absolute": 441,
+                "relative": 17.23
+              },
+              "previous": {
+                "absolute": 441,
+                "relative": 17.23
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 3
+            },
+            "previous": {
+              "absolute": 3
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_read",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 28672,
+              "current": {
+                "absolute": 4908,
+                "relative": 17.12
+              },
+              "previous": {
+                "absolute": 4908,
+                "relative": 17.12
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 2560,
+              "current": {
+                "absolute": 457,
+                "relative": 17.85
+              },
+              "previous": {
+                "absolute": 457,
+                "relative": 17.85
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 3
+            },
+            "previous": {
+              "absolute": 3
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_write",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 28672,
+              "current": {
+                "absolute": 4524,
+                "relative": 15.78
+              },
+              "previous": {
+                "absolute": 4564,
+                "relative": 15.92
+              },
+              "delta": {
+                "absolute": -40,
+                "relative": -0.14
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 2560,
+              "current": {
+                "absolute": 197,
+                "relative": 7.7
+              },
+              "previous": {
+                "absolute": 213,
+                "relative": 8.32
+              },
+              "delta": {
+                "absolute": -16,
+                "relative": -0.62
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 3
+            },
+            "previous": {
+              "absolute": 3
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        }
+      ],
+      "sizes": [
+        {
+          "name": "flash",
+          "maximum": 28672,
+          "delta": {
+            "absolute": {
+              "minimum": -40,
+              "maximum": 0
+            },
+            "relative": {
+              "minimum": -0.14,
+              "maximum": 0.0
+            }
+          }
+        },
+        {
+          "name": "RAM for global variables",
+          "maximum": 2560,
+          "delta": {
+            "absolute": {
+              "minimum": -16,
+              "maximum": 0
+            },
+            "relative": {
+              "minimum": -0.62,
+              "maximum": 0.0
+            }
+          }
+        }
+      ],
+      "warnings": {
+        "delta": {
+          "absolute": {
+            "minimum": 0,
+            "maximum": 0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/.github/workflows/testdata/artifact-source/multi-report-artifact/arduino-sam-arduino_due_x.json
+++ b/.github/workflows/testdata/artifact-source/multi-report-artifact/arduino-sam-arduino_due_x.json
@@ -1,0 +1,245 @@
+{
+  "commit_hash": "0123456789abcdef0123456789abcdef01234567",
+  "commit_url": "https://github.com/per1234/generate-size-deltas-report/commit/651f05f4d4aca30ac359e972c01568f873112d43",
+  "boards": [
+    {
+      "board": "arduino:sam:arduino_due_x",
+      "sketches": [
+        {
+          "name": "examples/MIDIUSB_clock",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 524288,
+              "current": {
+                "absolute": 11792,
+                "relative": 2.25
+              },
+              "previous": {
+                "absolute": 11792,
+                "relative": 2.25
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "previous": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "delta": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 5
+            },
+            "previous": {
+              "absolute": 5
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_loop",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 524288,
+              "current": {
+                "absolute": 11640,
+                "relative": 2.22
+              },
+              "previous": {
+                "absolute": 11640,
+                "relative": 2.22
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "previous": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "delta": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 6
+            },
+            "previous": {
+              "absolute": 6
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_read",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 524288,
+              "current": {
+                "absolute": 11808,
+                "relative": 2.25
+              },
+              "previous": {
+                "absolute": 11808,
+                "relative": 2.25
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "previous": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "delta": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 6
+            },
+            "previous": {
+              "absolute": 6
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_write",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 524288,
+              "current": {
+                "absolute": 11680,
+                "relative": 2.23
+              },
+              "previous": {
+                "absolute": 11680,
+                "relative": 2.23
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": "N/A",
+              "current": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "previous": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              },
+              "delta": {
+                "absolute": "N/A",
+                "relative": "N/A"
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 6
+            },
+            "previous": {
+              "absolute": 6
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        }
+      ],
+      "sizes": [
+        {
+          "name": "flash",
+          "maximum": 524288,
+          "delta": {
+            "absolute": {
+              "minimum": 0,
+              "maximum": 0
+            },
+            "relative": {
+              "minimum": 0.0,
+              "maximum": 0.0
+            }
+          }
+        },
+        {
+          "name": "RAM for global variables",
+          "maximum": "N/A",
+          "delta": {
+            "absolute": {
+              "minimum": "N/A",
+              "maximum": "N/A"
+            },
+            "relative": {
+              "minimum": "N/A",
+              "maximum": "N/A"
+            }
+          }
+        }
+      ],
+      "warnings": {
+        "delta": {
+          "absolute": {
+            "minimum": 0,
+            "maximum": 0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/.github/workflows/testdata/artifact-source/per-report-artifact/arduino-samd-mkrzero.json
+++ b/.github/workflows/testdata/artifact-source/per-report-artifact/arduino-samd-mkrzero.json
@@ -1,0 +1,245 @@
+{
+  "commit_hash": "0123456789abcdef0123456789abcdef01234567",
+  "commit_url": "https://github.com/per1234/generate-size-deltas-report/commit/651f05f4d4aca30ac359e972c01568f873112d43",
+  "boards": [
+    {
+      "board": "arduino:samd:mkrzero",
+      "sketches": [
+        {
+          "name": "examples/MIDIUSB_clock",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 262144,
+              "current": {
+                "absolute": 11976,
+                "relative": 4.57
+              },
+              "previous": {
+                "absolute": 11892,
+                "relative": 4.54
+              },
+              "delta": {
+                "absolute": 84,
+                "relative": 0.03
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 32768,
+              "current": {
+                "absolute": 2300,
+                "relative": 7.02
+              },
+              "previous": {
+                "absolute": 2300,
+                "relative": 7.02
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 3
+            },
+            "previous": {
+              "absolute": 3
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_loop",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 262144,
+              "current": {
+                "absolute": 11784,
+                "relative": 4.5
+              },
+              "previous": {
+                "absolute": 11784,
+                "relative": 4.5
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 32768,
+              "current": {
+                "absolute": 2296,
+                "relative": 7.01
+              },
+              "previous": {
+                "absolute": 2296,
+                "relative": 7.01
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 4
+            },
+            "previous": {
+              "absolute": 4
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_read",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 262144,
+              "current": {
+                "absolute": 11940,
+                "relative": 4.55
+              },
+              "previous": {
+                "absolute": 11968,
+                "relative": 4.57
+              },
+              "delta": {
+                "absolute": -28,
+                "relative": -0.01
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 32768,
+              "current": {
+                "absolute": 2296,
+                "relative": 7.01
+              },
+              "previous": {
+                "absolute": 2296,
+                "relative": 7.01
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 4
+            },
+            "previous": {
+              "absolute": 4
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        },
+        {
+          "name": "examples/MIDIUSB_write",
+          "compilation_success": true,
+          "sizes": [
+            {
+              "name": "flash",
+              "maximum": 262144,
+              "current": {
+                "absolute": 11808,
+                "relative": 4.5
+              },
+              "previous": {
+                "absolute": 11808,
+                "relative": 4.5
+              },
+              "delta": {
+                "absolute": 0,
+                "relative": 0.0
+              }
+            },
+            {
+              "name": "RAM for global variables",
+              "maximum": 32768,
+              "current": {
+                "absolute": 2064,
+                "relative": 6.3
+              },
+              "previous": {
+                "absolute": 2032,
+                "relative": 6.2
+              },
+              "delta": {
+                "absolute": 32,
+                "relative": 0.1
+              }
+            }
+          ],
+          "warnings": {
+            "current": {
+              "absolute": 4
+            },
+            "previous": {
+              "absolute": 4
+            },
+            "delta": {
+              "absolute": 0
+            }
+          }
+        }
+      ],
+      "sizes": [
+        {
+          "name": "flash",
+          "maximum": 262144,
+          "delta": {
+            "absolute": {
+              "minimum": -28,
+              "maximum": 84
+            },
+            "relative": {
+              "minimum": -0.01,
+              "maximum": 0.03
+            }
+          }
+        },
+        {
+          "name": "RAM for global variables",
+          "maximum": 32768,
+          "delta": {
+            "absolute": {
+              "minimum": 0,
+              "maximum": 32
+            },
+            "relative": {
+              "minimum": 0.0,
+              "maximum": 0.1
+            }
+          }
+        }
+      ],
+      "warnings": {
+        "delta": {
+          "absolute": {
+            "minimum": 0,
+            "maximum": 0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/.github/workflows/upload-report-artifact.yml
+++ b/.github/workflows/upload-report-artifact.yml
@@ -13,6 +13,20 @@ jobs:
   upload:
     runs-on: ubuntu-latest
 
+    env:
+      ARTIFACT_NAME_PREFIX: sketches-report-
+
+    strategy:
+      fail-fast: false
+      matrix:
+        parameters:
+          # Coverage for pre-actions/upload-artifact@v4 approach where all reports are stored in a single artifact.
+          - artifact-name-suffix: multi
+            reports-folder: multi-report-artifact
+          # Coverage for actions/upload-artifact@v4 approach where each report is stored in a separate artifact.
+          - artifact-name-suffix: arduino-samd-mkrzero
+            reports-folder: per-report-artifact
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,7 +40,7 @@ jobs:
           echo "SKETCHES_REPORTS_PATH=$SKETCHES_REPORTS_PATH" >> "$GITHUB_ENV"
           mkdir --parents "$SKETCHES_REPORTS_PATH"
 
-          cd "${{ github.workspace }}/.github/workflows/testdata/sketches-reports/"
+          cd "${{ github.workspace }}/.github/workflows/testdata/artifact-source/${{ matrix.parameters.reports-folder }}"
           for reportFile in *.json; do
             jq '.commit_hash = "${{ github.event.pull_request.head.sha }}"' "$reportFile" > "${SKETCHES_REPORTS_PATH}/$reportFile"
           done
@@ -36,4 +50,4 @@ jobs:
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-          name: sketches-reports
+          name: ${{ env.ARTIFACT_NAME_PREFIX }}${{ matrix.parameters.artifact-name-suffix }}


### PR DESCRIPTION
The action was originally designed for a use case where there will only be a single sketches reports workflow artifact. Due to [a change](https://github.com/actions/upload-artifact#breaking-changes) in the "**actions/upload-artifact**" GitHub Actions action, it became necessary to add the capability for the "**arduino/report-size-deltas**" action to be able to consume reports from multiple artifacts (https://github.com/arduino/report-size-deltas/pull/78).

The "**Upload test sketches report artifact**" GitHub Actions workflow is here updated to produce multiple test data artifacts in order to allow the ["**Run integration tests**" workflow](https://github.com/arduino/report-size-deltas/blob/main/.github/workflows/test-integration.yml) to provide coverage for the new capability.

As was previously the case, one of the artifacts uploaded by the workflow contains multiple sketches report files in order to provide test data necessary to continue providing coverage for the <=`actions/upload-artifact@v3` single artifact system. Even though the produced test data (multiple artifacts, with multiple reports in a single artifact) would not occur under real world usage, it is the cleanest way (the alternative being to create and maintain separate copies of the system implemented in the [`report-target-pr` branch](https://github.com/arduino/report-size-deltas/tree/report-target-pr) for each use pattern) to provide effective integration test coverage.