### PR TITLE
Generate v1 and v2 format test data artifacts

### DIFF
--- a/.github/workflows/upload-report-artifact.yml
+++ b/.github/workflows/upload-report-artifact.yml
@@ -22,9 +22,11 @@ jobs:
         parameters:
           # Coverage for pre-actions/upload-artifact@v4 approach where all reports are stored in a single artifact.
           - artifact-name-suffix: multi
+            artifact-version: 1
             reports-folder: multi-report-artifact
           # Coverage for actions/upload-artifact@v4 approach where each report is stored in a separate artifact.
           - artifact-name-suffix: arduino-samd-mkrzero
+            artifact-version: 2
             reports-folder: per-report-artifact
 
     steps:
@@ -45,8 +47,19 @@ jobs:
             jq '.commit_hash = "${{ github.event.pull_request.head.sha }}"' "$reportFile" > "${SKETCHES_REPORTS_PATH}/$reportFile"
           done
 
-      - name: Save sketches report as workflow artifact
+      - name: Save sketches report as v1 format workflow artifact
+        if: matrix.parameters.artifact-version == '1'
+        # actions/upload-artifact 3.x is the last version to produce v1 format artifacts:
+        # https://github.com/actions/upload-artifact/blob/main/README.md#v4---whats-new
         uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.ARTIFACT_NAME_PREFIX }}${{ matrix.parameters.artifact-name-suffix }}
+
+      - name: Save sketches report as v2 format workflow artifact
+        if: matrix.parameters.artifact-version == '2'
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}


### PR DESCRIPTION
A [significant change](https://github.com/actions/toolkit/tree/main/packages/artifact#v2---whats-new) was made to the nature of GitHub Actions workflow artifacts starting from the 2.x release of the [`@actions/artifact` package](https://github.com/actions/toolkit/tree/main/packages/artifact), which was introduced in the [4.0.0](https://github.com/actions/upload-artifact/releases/tag/v4.0.0) release of the "[**actions/upload-artifact**](https://github.com/actions/upload-artifact)" GitHub Actions action.

It is necessary to provide integration test coverage for compatibility of the "**arduino/report-size-deltas**" action with the v2 format artifacts produced by `actions/upload-artifact@v4`. It is also important to continue to cover compatibility with the v1 format artifacts produced by `actions/upload-artifact@v3`, to support users who have not gotten around to updating that action dependency in their sketch compilation workflows (especially since the [breaking change](https://github.com/actions/upload-artifact/blob/main/README.md#breaking-changes) introduced by actions/upload-artifact@v4 will make it necessary to adjust the configuration of the workflow (https://github.com/per1234/.github/issues/109)).

The chosen approach is to configure the ["Upload test sketches report artifact" workflow](https://github.com/arduino/report-size-deltas/blob/report-target-pr/.github/workflows/upload-report-artifact.yml) to use `actions/upload-artifact@v3` when uploading one of the test data artifacts and `actions/upload-artifact@v4` when uploading the other. Even though the produced test data would not occur under real world usage, it is the cleanest way (the alternative being to create and maintain separate copies of the system implemented in the [`report-target-pr`](https://github.com/arduino/report-size-deltas/tree/report-target-pr) branch for each major version of the **actions/upload-artifact** action) to provide effective integration test coverage.