### PR TITLE
Increase visibility of error message when action fails due to HTTP request error

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,6 @@ filterwarnings =
     ignore::DeprecationWarning
     ignore::ResourceWarning
 
-# --capture=no - disable per-test capture
 # --tb=long sets the length of the traceback in case of failures
-addopts = --capture=no --tb=long --verbose
+addopts = --tb=long --verbose
 pythonpath = reportsizedeltas

--- a/reportsizedeltas/reportsizedeltas.py
+++ b/reportsizedeltas/reportsizedeltas.py
@@ -630,19 +630,26 @@ class ReportSizeDeltas:
         request = urllib.request.Request(url=url, headers=headers, data=data)
 
         retry_count = 0
-        while retry_count <= maximum_urlopen_retries:
-            retry_count += 1
+        while True:
             try:
                 # The rate limit API is not subject to rate limiting
                 if url.startswith("https://api.github.com") and not url.startswith("https://api.github.com/rate_limit"):
                     self.handle_rate_limiting()
                 return urllib.request.urlopen(url=request)
             except urllib.error.HTTPError as exception:
-                if not determine_urlopen_retry(exception=exception):
-                    raise exception
+                if determine_urlopen_retry(exception=exception):
+                    if retry_count < maximum_urlopen_retries:
+                        retry_count += 1
+                        continue
+                    else:
+                        # Maximum retries reached without successfully opening URL
+                        print("Maximum number of URL load retries exceeded")
 
-        # Maximum retries reached without successfully opening URL
-        raise TimeoutError("Maximum number of URL load retries exceeded")
+                print(f"::error::{exception.__class__.__name__}: {exception}")
+                for line in exception.fp:
+                    print(line.decode(encoding="utf-8", errors="ignore"))
+
+                raise exception
 
     def handle_rate_limiting(self) -> None:
         """Check whether the GitHub API request limit has been reached.

--- a/reportsizedeltas/reportsizedeltas.py
+++ b/reportsizedeltas/reportsizedeltas.py
@@ -637,7 +637,7 @@ class ReportSizeDeltas:
                 if url.startswith("https://api.github.com") and not url.startswith("https://api.github.com/rate_limit"):
                     self.handle_rate_limiting()
                 return urllib.request.urlopen(url=request)
-            except Exception as exception:
+            except urllib.error.HTTPError as exception:
                 if not determine_urlopen_retry(exception=exception):
                     raise exception
 
@@ -664,7 +664,7 @@ class ReportSizeDeltas:
             sys.exit(0)
 
 
-def determine_urlopen_retry(exception) -> bool:
+def determine_urlopen_retry(exception: urllib.error.HTTPError) -> bool:
     """Determine whether the exception warrants another attempt at opening the URL.
     If so, delay then return True. Otherwise, return False.
 

--- a/reportsizedeltas/tests/test_reportsizedeltas.py
+++ b/reportsizedeltas/tests/test_reportsizedeltas.py
@@ -901,9 +901,11 @@ def test_raw_http_request(mocker):
     urllib.request.urlopen.assert_called_once_with(url=request)
 
     # urllib.request.urlopen() has non-recoverable exception
-    urllib.request.urlopen.side_effect = Exception()
+    urllib.request.urlopen.side_effect = urllib.error.HTTPError(
+        url="http://example.com", code=404, msg="", hdrs=None, fp=None
+    )
     mocker.patch("reportsizedeltas.determine_urlopen_retry", autospec=True, return_value=False)
-    with pytest.raises(expected_exception=Exception):
+    with pytest.raises(expected_exception=urllib.error.HTTPError):
         report_size_deltas.raw_http_request(url=url, data=data)
 
     # urllib.request.urlopen() has potentially recoverable exceptions, but exceeds retry count

--- a/reportsizedeltas/tests/test_reportsizedeltas.py
+++ b/reportsizedeltas/tests/test_reportsizedeltas.py
@@ -910,7 +910,7 @@ def test_raw_http_request(mocker):
 
     # urllib.request.urlopen() has potentially recoverable exceptions, but exceeds retry count
     reportsizedeltas.determine_urlopen_retry.return_value = True
-    with pytest.raises(expected_exception=TimeoutError):
+    with pytest.raises(expected_exception=urllib.error.HTTPError):
         report_size_deltas.raw_http_request(url=url, data=data)
 
 


### PR DESCRIPTION
The **arduino/report-size-deltas** action relies on the [GitHub REST API](https://docs.github.com/rest). It makes HTTP requests to various API endpoints during each workflow run.

These requests might produce an exception due to transient network outages, misconfiguration of the workflow, or a problem with the action. This will cause the action's step in the workflow run to fail. The maintainer of the repository in which the action is used may then need to investigate the cause of the failure.

Previously, the cause of the failure could only be determined by evaluating the workflow run logs, which are somewhat unfriendly due to containing the Python stack trace produced by the HTTP request exception. The significant error message is here made visible as an annotation on the workflow run summary page through the use of an ["error" workflow command](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message):

![image](https://github.com/arduino/report-size-deltas/assets/8572152/db9d23be-1259-443e-aed4-b1ab459dadbd)
