### PR TITLE
Use all recommended headers in GitHub API HTTP requests

### DIFF
--- a/reportsizedeltas/reportsizedeltas.py
+++ b/reportsizedeltas/reportsizedeltas.py
@@ -627,7 +627,7 @@ class ReportSizeDeltas:
 
         headers = {
             "Accept": "application/vnd.github+json",
-            "Authorization": "token " + self.token,
+            "Authorization": "Bearer " + self.token,
             # GitHub recommends using user name as User-Agent (https://developer.github.com/v3/#user-agent-required)
             "User-Agent": self.repository_name.split("/")[0],
         }

--- a/reportsizedeltas/reportsizedeltas.py
+++ b/reportsizedeltas/reportsizedeltas.py
@@ -625,8 +625,12 @@ class ReportSizeDeltas:
 
         logger.info("Opening URL: " + url)
 
-        # GitHub recommends using user name as User-Agent (https://developer.github.com/v3/#user-agent-required)
-        headers = {"Authorization": "token " + self.token, "User-Agent": self.repository_name.split("/")[0]}
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": "token " + self.token,
+            # GitHub recommends using user name as User-Agent (https://developer.github.com/v3/#user-agent-required)
+            "User-Agent": self.repository_name.split("/")[0],
+        }
         request = urllib.request.Request(url=url, headers=headers, data=data)
 
         retry_count = 0

--- a/reportsizedeltas/reportsizedeltas.py
+++ b/reportsizedeltas/reportsizedeltas.py
@@ -630,6 +630,7 @@ class ReportSizeDeltas:
             "Authorization": "Bearer " + self.token,
             # GitHub recommends using user name as User-Agent (https://developer.github.com/v3/#user-agent-required)
             "User-Agent": self.repository_name.split("/")[0],
+            "X-GitHub-Api-Version": "2022-11-28",
         }
         request = urllib.request.Request(url=url, headers=headers, data=data)
 

--- a/reportsizedeltas/tests/test_reportsizedeltas.py
+++ b/reportsizedeltas/tests/test_reportsizedeltas.py
@@ -891,7 +891,7 @@ def test_raw_http_request(mocker):
         url=url,
         headers={
             "Accept": "application/vnd.github+json",
-            "Authorization": "token " + token,
+            "Authorization": "Bearer " + token,
             "User-Agent": user_name,
         },
         data=data,

--- a/reportsizedeltas/tests/test_reportsizedeltas.py
+++ b/reportsizedeltas/tests/test_reportsizedeltas.py
@@ -893,6 +893,7 @@ def test_raw_http_request(mocker):
             "Accept": "application/vnd.github+json",
             "Authorization": "Bearer " + token,
             "User-Agent": user_name,
+            "X-GitHub-Api-Version": "2022-11-28",
         },
         data=data,
     )

--- a/reportsizedeltas/tests/test_reportsizedeltas.py
+++ b/reportsizedeltas/tests/test_reportsizedeltas.py
@@ -888,7 +888,13 @@ def test_raw_http_request(mocker):
     report_size_deltas.raw_http_request(url=url, data=data)
 
     urllib.request.Request.assert_called_once_with(
-        url=url, headers={"Authorization": "token " + token, "User-Agent": user_name}, data=data
+        url=url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": "token " + token,
+            "User-Agent": user_name,
+        },
+        data=data,
     )
     # URL is subject to GitHub API rate limiting
     report_size_deltas.handle_rate_limiting.assert_called_once()


### PR DESCRIPTION
See:

https://docs.github.com/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2022-11-28#headers