### PR TITLE
Don't include HTTP headers from GitHub API request in redirected artifact download request

### DIFF
--- a/reportsizedeltas/reportsizedeltas.py
+++ b/reportsizedeltas/reportsizedeltas.py
@@ -625,14 +625,11 @@ class ReportSizeDeltas:
 
         logger.info("Opening URL: " + url)
 
-        headers = {
-            "Accept": "application/vnd.github+json",
-            "Authorization": "Bearer " + self.token,
-            # GitHub recommends using user name as User-Agent (https://developer.github.com/v3/#user-agent-required)
-            "User-Agent": self.repository_name.split("/")[0],
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
-        request = urllib.request.Request(url=url, headers=headers, data=data)
+        request = urllib.request.Request(url=url, data=data)
+        request.add_unredirected_header(key="Accept", val="application/vnd.github+json")
+        request.add_unredirected_header(key="Authorization", val="Bearer " + self.token)
+        request.add_unredirected_header(key="User-Agent", val=self.repository_name.split("/")[0])
+        request.add_unredirected_header(key="X-GitHub-Api-Version", val="2022-11-28")
 
         retry_count = 0
         while True:


### PR DESCRIPTION
In the use case where the **arduino/report-size-deltas** action is [ran from a GitHub Actions workflow triggered by a `schedule` event](https://github.com/arduino/report-size-deltas#run-from-a-scheduled-workflow), it downloads the sketches report file from a workflow artifact.

The [GitHub REST API](https://docs.github.com/en/rest) is used to perform this artifact download. The artifact download process is:

1. Action sends request to [`/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}` endpoint](https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#download-an-artifact)
1. API responds with HTTP [302 status](https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#download-an-artifact--status-codes)
1. Action sends request to temporary file download URL provided by the API response
1. Artifact file is downloaded

The API request at step (1) must be [authenticated using a GitHub access token](https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28#authenticating-with-a-personal-access-token). This token is passed via the `Authorization` HTTP header in the request.

No authentication is required for the download request at step (3).

The [`urllib.request`](https://docs.python.org/3/library/urllib.request.html) Python module is used to perform the HTTP requests. By default, this module [passes the headers from the original request to the redirect request](https://docs.python.org/3/library/urllib.request.html#urllib.request.Request:~:text=will%20be%20treated%20as%20if%20add_header()%20was%20called%20with%20each%20key%20and%20value%20as%20arguments).

Although these headers were superfluous, they didn't affect the download request when the target artifact was of the v1 format generated by version 3.x and earlier of the [**actions/upload-artifact**](https://github.com/actions/upload-artifact) action. A new [v2 artifact format](https://github.com/actions/toolkit/tree/main/packages/artifact#v2---whats-new) was introduced in the [4.0.0](https://github.com/actions/upload-artifact/releases/tag/v4.0.0) release of the **actions/upload-artifact** action. Previously, the request at step (3) of the artifact download procedure would fail when the target artifact had the v2 format:

https://github.com/arduino/report-size-deltas/actions/runs/7633691244/job/20796387110#step:3:164

```text
urllib.error.HTTPError: HTTP Error 400: Authentication information is not given in the correct format. Check the value of Authorization header.
Error: HTTPError: HTTP Error 400: Authentication information is not given in the correct format. Check the value of Authorization header.
<?xml version="1.0" encoding="utf-8"?><Error><Code>InvalidAuthenticationInfo</Code><Message>Authentication information is not given in the correct format. Check the value of Authorization header.

RequestId:1f13170a-001e-0076-5f5d-4e8d15000000

Time:2024-01-24T00:35:22.8264229Z</Message></Error>
```

The cause of the failure was the inclusion of the `Authorization` HTTP header in the download request. The `urllib.request` Python module can be configured to pass a header in the original request but not in the redirected request by defining the header via the [`Request.add_unredirected_header` method](https://docs.python.org/3/library/urllib.request.html#urllib.request.Request.add_unredirected_header) instead of in [the `Request` instantiation](https://docs.python.org/3/library/urllib.request.html#urllib.request.Request). This provides compatibility for using the action with v2 format artifacts.