### PR TITLE
Remove non-functional bold tags from Mermaid code

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -94,7 +94,7 @@ flowchart TB
   subgraph main[" "]
     direction TB
 
-    subgraph compileWorkflow["<b>Sketch compilation workflow run</b>"]
+    subgraph compileWorkflow["Sketch compilation workflow run"]
       direction TB
 
       unoJob["arduino:avr:uno<br />job"]
@@ -113,13 +113,13 @@ flowchart TB
       mkrzeroArtifact["sketches-reports-arduino-samd-mkrzero<br />artifact"]
     end
 
-    subgraph reportWorkflow["<b>Size deltas report workflow run</b>"]
+    subgraph reportWorkflow["Size deltas report workflow run"]
       direction TB
 
       reportAction["arduino/report-size-deltas<br />action"]
     end
 
-    subgraph pr["<b>Pull request</b>"]
+    subgraph pr["Pull request"]
       direction TB
 
       comment["Size deltas report<br />comment"]


### PR DESCRIPTION
In order to make it easier for the reader to understand the function of complementary example workflows provided in the FAQ, a chart is used to explain the flow of sketches report data between the steps and jobs in the sketch compilation workflow and between the sketch compilation workflow and the deltas report workflow.

The [**Mermaid**](https://mermaid.js.org/) diagramming language is used to produce this flowchart ([GitHub automatically renders Mermaid code in `mermaid` code blocks of Markdown files](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams)).

The text in charts can be styled and formatted using HTML tags in the Mermaid code. Previously, `<b>` tags were used on the subgraph titles in order to improve the readability of the chart. Since the time the chart was created, something changed in GitHub's Markdown/Mermaid rendering system that causes these tags to no longer cause the intended text styling. They now are simply printed as text, meaning they now have a harmful effect on the readability:

![image](https://github.com/arduino/report-size-deltas/assets/8572152/1d2a7814-b1f4-41d7-8fec-ba520b3b2580)

For this reason, the tags are hereby removed. No alternative is available. The `<br />` tags continue to work as expected (though unfortunately the text is now left aligned ![image](https://github.com/arduino/report-size-deltas/assets/8572152/f9d5b88c-fd15-4fc5-9336-7a0deb21950b) instead of being centered as before) so they are retained.