### PR TITLE
Update reference link re: GITHUB_TOKEN permissions for workflow runs triggered by events from forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The action can be used in two ways:
 
 Recommended for public repositories.
 
-The use of a [scheduled workflow](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule) is necessary in order for the action to have the [write permissions required to comment on pull requests submitted from forks](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token).
+The use of a [scheduled workflow](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule) is necessary in order for the action to have the [write permissions required to comment on pull requests submitted from forks](https://docs.github.com/actions/reference/workflows-and-actions/workflow-syntax#how-permissions-are-calculated-for-a-workflow-job).
 
 In this usage, the `sketches-reports-source` input defines the regular expression matching the names of the workflow artifacts that contain the memory usage data, as specified to the [`actions/upload-artifact`](https://github.com/actions/upload-artifact) action via its `name` input.
 


### PR DESCRIPTION
The personal access token used by the action to make the report comment must have write permissions. The action uses the automatically generated `GITHUB_TOKEN` token by default.

When the action is used in a public repository, it is essential for the maintainer of the repository to understand how the permissions of that token work. For security reasons, the permissions of the token are downgraded to write when used in a workflow run triggered by an event that comes from a fork. This is the reason why another approach must be used to run the action's workflow in public repositories.

The action documentation provides an explanation of this, but relies on the GitHub Actions documentation to explain the details of the token permissions downgrade system. Due to changes in the GitHub documentation, the linked page no longer contains that information. The link is hereby updated to point to the information in its new location in the GitHub Actions docs.